### PR TITLE
H5 group list in IOManager

### DIFF
--- a/src/larcv3/core/dataformat/IOManager.cxx
+++ b/src/larcv3/core/dataformat/IOManager.cxx
@@ -743,7 +743,15 @@ EventBase* IOManager::get_data(const size_t id) {
     // std::cout << "_in_index: " << _in_index << std::endl;
     // std::cout << "_current_offset: " << _current_offset << std::endl;
 
-    H5::Group group = _in_open_file.openGroup(group_name);
+    H5::Group group;
+    auto iter = _groups.find(group_name);
+    if (iter == _groups.end()) {
+      group = _in_open_file.openGroup(group_name);
+      _groups[group_name] = group;
+    } else {
+      group = iter->second;
+    }
+
     try {
       _product_ptr_v[id]->deserialize(&group, _in_index - _current_offset);
     }

--- a/src/larcv3/core/dataformat/IOManager.h
+++ b/src/larcv3/core/dataformat/IOManager.h
@@ -195,11 +195,13 @@ namespace larcv3 {
     H5::DataSet    _active_in_event_id_dataset;
     H5::DataSpace  _active_in_event_id_dataspace;
 
+    std::map<std::string, H5::Group> _groups;
+
 
     // Keeping track of products and producers:
     std::map<larcv3::ProducerName_t, larcv3::ProducerID_t> _key_list;
     size_t                          _product_ctr;
-    std::vector<larcv3::EventBase*>  _product_ptr_v;
+    std::vector<larcv3::EventBase*> _product_ptr_v;
     std::vector<std::string>        _product_type_v;
     std::vector<std::string>        _producer_name_v;
 


### PR DESCRIPTION
A list of open groups is stored in a map so that the same group is not opened every time.