### PR TITLE
This commit replaces all of the hdf5 C++ API calls with hdf5 C API.  …

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -39,7 +39,7 @@ set(PROJECT_SOURCE_DIR "./")
 include_directories("./")
 
 # IO needs HDF5:
-find_package(HDF5 REQUIRED COMPONENTS C CXX)
+find_package(HDF5 REQUIRED COMPONENTS C)
 include_directories(${HDF5_INCLUDE_DIR})
 
 # Many packages need python:

--- a/src/larcv3/CMakeLists.txt
+++ b/src/larcv3/CMakeLists.txt
@@ -23,7 +23,7 @@ if (OpenMP_CXX_FOUND)
 endif()
 
 # Link against hdf5:
-target_link_libraries(larcv3 ${HDF5_CXX_LIBRARIES})
+target_link_libraries(larcv3 ${HDF5_C_LIBRARIES})
 
 # Link against python:
 target_link_libraries(larcv3 ${PYTHON_LIBRARIES})

--- a/src/larcv3/core/dataformat/DataFormatTypes.cxx
+++ b/src/larcv3/core/dataformat/DataFormatTypes.cxx
@@ -10,74 +10,85 @@ namespace larcv3{
 
 
   template<>
-  H5::DataType get_datatype<int>()                {
-    H5::DataType _copied_type(H5::PredType::NATIVE_INT);
+  hid_t get_datatype<int>()                {
+    hid_t _copied_type(H5T_NATIVE_INT);
     return _copied_type;}
 
   template<>
-  H5::DataType get_datatype<bool>()               {
-    H5::DataType _copied_type(H5::PredType::NATIVE_HBOOL);
+  hid_t get_datatype<bool>()               {
+    hid_t _copied_type(H5T_NATIVE_HBOOL);
     return _copied_type;}
 
   template<>
-  H5::DataType get_datatype<float>()              {
-    H5::DataType _copied_type(H5::PredType::NATIVE_FLOAT);
+  hid_t get_datatype<float>()              {
+    hid_t _copied_type(H5T_NATIVE_FLOAT);
     return _copied_type;}
 
   template<>
-  H5::DataType get_datatype<double>()             {
-    H5::DataType _copied_type(H5::PredType::NATIVE_DOUBLE);
+  hid_t get_datatype<double>()             {
+    hid_t _copied_type(H5T_NATIVE_DOUBLE);
     return _copied_type;}
 
   template<>
-  H5::DataType get_datatype<unsigned short>()     {
-    H5::DataType _copied_type(H5::PredType::NATIVE_USHORT);
+  hid_t get_datatype<unsigned short>()     {
+    hid_t _copied_type(H5T_NATIVE_USHORT);
     return _copied_type;}
 
   template<>
-  H5::DataType get_datatype<unsigned int>()       {
-    H5::DataType _copied_type(H5::PredType::NATIVE_UINT);
+  hid_t get_datatype<unsigned int>()       {
+    hid_t _copied_type(H5T_NATIVE_UINT);
     return _copied_type;}
 
   template<>
-  H5::DataType get_datatype<short>()              {
-    H5::DataType _copied_type(H5::PredType::NATIVE_SHORT);
+  hid_t get_datatype<short>()              {
+    hid_t _copied_type(H5T_NATIVE_SHORT);
     return _copied_type;}
 
   template<>
-  H5::DataType get_datatype<unsigned long long>() {
-    H5::DataType _copied_type(H5::PredType::NATIVE_ULLONG);
+  hid_t get_datatype<unsigned long long>() {
+    hid_t _copied_type(H5T_NATIVE_ULLONG);
     return _copied_type;}
   
   template<>
-  H5::DataType get_datatype<size_t>()             {
-    H5::DataType _copied_type(H5::PredType::NATIVE_HSIZE);
+  hid_t get_datatype<size_t>()             {
+    hid_t _copied_type(H5T_NATIVE_HSIZE);
     return _copied_type;}
 
   template<>
-  H5::DataType get_datatype<ShapeType_t>()        {return get_datatype<int>();}
+  hid_t get_datatype<ShapeType_t>()        {return get_datatype<int>();}
 
   template<>
-  H5::DataType get_datatype<long>()               {
-    H5::DataType _long_copy(H5::PredType::NATIVE_LONG);
+  hid_t get_datatype<long>()               {
+    hid_t _long_copy(H5T_NATIVE_LONG);
     return _long_copy;
   }
 
 
   template<>
-  H5::DataType get_datatype<Extents_t>()          {
-    H5::CompType datatype(sizeof(Extents_t));
-    datatype.insertMember(H5std_string("first"), offsetof(struct Extents_t, first), get_datatype<unsigned int>());
-    datatype.insertMember(H5std_string("N"),     offsetof(struct Extents_t, n),     get_datatype<unsigned int>());
+  hid_t get_datatype<Extents_t>()          {
+
+    hid_t datatype;
+    herr_t status;
+    datatype = H5Tcreate (H5T_COMPOUND, sizeof (Extents_t));
+    status = H5Tinsert (datatype, "first",
+                HOFFSET (Extents_t, first), larcv3::get_datatype<unsigned int>());
+    status = H5Tinsert (datatype, "N", 
+                HOFFSET (Extents_t, n),     larcv3::get_datatype<unsigned int>());
     return datatype;
+
   }
 
   template<>
-  H5::DataType get_datatype<IDExtents_t>()          {
-    H5::CompType datatype(sizeof(IDExtents_t));
-    datatype.insertMember(H5std_string("first"), offsetof(struct IDExtents_t, first), get_datatype<unsigned int>());
-    datatype.insertMember(H5std_string("ID"),    offsetof(struct IDExtents_t, id),    get_datatype<unsigned int>());
-    datatype.insertMember(H5std_string("N"),     offsetof(struct IDExtents_t, n),     get_datatype<unsigned int>());
+  hid_t get_datatype<IDExtents_t>()          {
+    hid_t datatype;
+    herr_t status;
+    datatype = H5Tcreate (H5T_COMPOUND, sizeof (IDExtents_t));
+    status = H5Tinsert (datatype, "first",
+                HOFFSET (IDExtents_t, first), larcv3::get_datatype<unsigned int>());
+    status = H5Tinsert (datatype, "N", 
+                HOFFSET (IDExtents_t, n),     larcv3::get_datatype<unsigned int>());
+    status = H5Tinsert (datatype, "ID",    
+                HOFFSET (IDExtents_t, id),    larcv3::get_datatype<unsigned int>());
     return datatype;
   }
 

--- a/src/larcv3/core/dataformat/DataFormatTypes.h
+++ b/src/larcv3/core/dataformat/DataFormatTypes.h
@@ -2,7 +2,7 @@
 #define __LARCV3DATAFORMAT_DATAFORMATTYPES_H__
 
 #include "larcv3/core/base/LArCVTypes.h"
-#include "H5Cpp.h"
+#include "hdf5.h"
 #include <vector>
 #include <set>
 
@@ -109,7 +109,7 @@ namespace larcv3 {
 #ifndef SWIG
 
   template <typename T>
-  H5::DataType get_datatype();
+  hid_t get_datatype();
 
 
 #endif

--- a/src/larcv3/core/dataformat/EventBase.cxx
+++ b/src/larcv3/core/dataformat/EventBase.cxx
@@ -7,9 +7,15 @@
 
 namespace larcv3{
     EventBase::~EventBase(){
-        for (auto & p : _data_types){
-            delete p;
-        }
+        // for (auto & p : _data_types){
+        //     delete p;
+        // }
+    }
+
+    int EventBase::get_num_objects(hid_t group){
+        hsize_t  num_objects[1] = {0};
+        H5Gget_num_objs(group, num_objects);
+        return num_objects[0];
     }
 }
 #endif

--- a/src/larcv3/core/dataformat/EventBase.h
+++ b/src/larcv3/core/dataformat/EventBase.h
@@ -35,18 +35,21 @@ namespace larcv3 {
     virtual ~EventBase() = 0;
 
     virtual void clear() = 0;
-    virtual void initialize(H5::Group *, uint compression) = 0;
-    virtual void serialize(H5::Group * group) = 0;
-    virtual void deserialize(H5::Group * group, size_t entry, bool reopen_groups) = 0;
+    virtual void initialize (hid_t group, uint compression) = 0;
+    virtual void serialize  (hid_t group) = 0;
+    virtual void deserialize(hid_t group, size_t entry, bool reopen_groups) = 0;
+    virtual void finalize() = 0;
 
-    virtual void open_in_datasets(H5::Group * group ) = 0;
-    virtual void open_out_datasets(H5::Group * group ) = 0;
+    virtual void open_in_datasets(hid_t group ) = 0;
+    virtual void open_out_datasets(hid_t group ) = 0;
 
-    std::vector<H5::DataSet>   _open_in_datasets;
-    std::vector<H5::DataSpace> _open_in_dataspaces;
-    std::vector<H5::DataSet>   _open_out_datasets;
-    std::vector<H5::DataSpace> _open_out_dataspaces;
-    std::vector<H5::DataType*> _data_types;
+    std::vector<hid_t> _open_in_datasets;
+    std::vector<hid_t> _open_in_dataspaces;
+    std::vector<hid_t> _open_out_datasets;
+    std::vector<hid_t> _open_out_dataspaces;
+    std::vector<hid_t> _data_types;
+
+    int get_num_objects(hid_t group);
 
 // #endif
   };

--- a/src/larcv3/core/dataformat/EventID.h
+++ b/src/larcv3/core/dataformat/EventID.h
@@ -15,6 +15,7 @@
 #define __LARCV3DATAFORMAT_EVENTID_H
 
 #include <iostream>
+#include "hdf5.h"
 #include "larcv3/core/dataformat/DataFormatTypes.h"
 
 namespace larcv3 {
@@ -88,11 +89,16 @@ class EventID {
 
 #ifndef SWIG
   public: 
-    static H5::CompType get_datatype() {
-      H5::CompType datatype(sizeof(EventID));
-      datatype.insertMember(H5std_string("run"),    offsetof(EventID, _run),    larcv3::get_datatype<long>());
-      datatype.insertMember(H5std_string("subrun"), offsetof(EventID, _subrun), larcv3::get_datatype<long>());
-      datatype.insertMember(H5std_string("event"),  offsetof(EventID, _event),  larcv3::get_datatype<long>());
+    static hid_t get_datatype() {
+      hid_t datatype;
+      herr_t status;
+      datatype = H5Tcreate (H5T_COMPOUND, sizeof (EventID));
+      status = H5Tinsert (datatype, "run",
+                  HOFFSET (EventID, _run), larcv3::get_datatype<long>());
+      status = H5Tinsert (datatype, "subrun", 
+                  HOFFSET (EventID, _subrun), larcv3::get_datatype<long>());
+      status = H5Tinsert (datatype, "event",
+                  HOFFSET (EventID, _event), larcv3::get_datatype<long>());
       return datatype;
     }
 #endif

--- a/src/larcv3/core/dataformat/EventParticle.cxx
+++ b/src/larcv3/core/dataformat/EventParticle.cxx
@@ -18,8 +18,8 @@ namespace larcv3{
   EventParticle::EventParticle(){
 
     _data_types.resize(N_DATASETS);
-    _data_types[EXTENTS_DATASET] = new H5::DataType(larcv3::get_datatype<Extents_t>());
-    _data_types[PARTICLES_DATASET] = new H5::DataType(larcv3::Particle::get_datatype());
+    _data_types[EXTENTS_DATASET] = larcv3::get_datatype<Extents_t>();
+    _data_types[PARTICLES_DATASET] = larcv3::Particle::get_datatype();
 
 
   }
@@ -59,41 +59,50 @@ namespace larcv3{
 // #ifndef SWIG
 
 
-  void EventParticle::open_in_datasets(H5::Group * group){
+  void EventParticle::finalize(){
+    for (size_t i =0; i < _open_in_datasets.size(); i ++){
+      H5Dclose(_open_in_datasets[i]);
+    }
+    for (size_t i =0; i < _open_out_datasets.size(); i ++){
+      H5Dclose(_open_out_datasets[i]);
+    }
+  }
+
+  void EventParticle::open_in_datasets(hid_t group){
 
     if (_open_in_datasets.size() < N_DATASETS ){
        _open_in_datasets.resize(N_DATASETS);
        _open_in_dataspaces.resize(N_DATASETS);
-       
-       _open_in_datasets[EXTENTS_DATASET]         = group->openDataSet("extents");
-       _open_in_dataspaces[EXTENTS_DATASET]       = _open_in_datasets[EXTENTS_DATASET].getSpace();
 
-       _open_in_datasets[PARTICLES_DATASET]         = group->openDataSet("particles");
-       _open_in_dataspaces[PARTICLES_DATASET]       = _open_in_datasets[PARTICLES_DATASET].getSpace();
+       _open_in_datasets[EXTENTS_DATASET]         = H5Dopen(group, "extents", H5P_DEFAULT);
+       _open_in_dataspaces[EXTENTS_DATASET]       = H5Dget_space(_open_in_datasets[EXTENTS_DATASET]);
+
+       _open_in_datasets[PARTICLES_DATASET]       = H5Dopen(group, "particles", H5P_DEFAULT);
+       _open_in_dataspaces[PARTICLES_DATASET]     = H5Dget_space(_open_in_datasets[PARTICLES_DATASET]);
 
     }
 
     return;
   }
 
-  void EventParticle::open_out_datasets(H5::Group * group){
+  void EventParticle::open_out_datasets(hid_t group){
 
     if (_open_out_datasets.size() < N_DATASETS ){
        _open_out_datasets.resize(N_DATASETS);
        _open_out_dataspaces.resize(N_DATASETS);
        
-       _open_out_datasets[EXTENTS_DATASET]         = group->openDataSet("extents");
-       _open_out_dataspaces[EXTENTS_DATASET]       = _open_out_datasets[EXTENTS_DATASET].getSpace();
+       _open_out_datasets[EXTENTS_DATASET]         = H5Dopen(group, "extents", H5P_DEFAULT);
+       _open_out_dataspaces[EXTENTS_DATASET]       = H5Dget_space(_open_out_datasets[EXTENTS_DATASET]);
 
-       _open_out_datasets[PARTICLES_DATASET]         = group->openDataSet("particles");
-       _open_out_dataspaces[PARTICLES_DATASET]       = _open_out_datasets[PARTICLES_DATASET].getSpace();
+       _open_out_datasets[PARTICLES_DATASET]       = H5Dopen(group, "particles", H5P_DEFAULT);
+       _open_out_dataspaces[PARTICLES_DATASET]     = H5Dget_space(_open_out_datasets[PARTICLES_DATASET]);
 
     }
 
     return;
   }
 
-  void EventParticle::serialize(H5::Group * group){
+  void EventParticle::serialize(hid_t group){
 
 
     // Serialization is a multi step process.  
@@ -129,7 +138,8 @@ namespace larcv3{
 
     // Get the dataset current size
     hsize_t particles_dims_current[1];
-    _open_out_dataspaces[PARTICLES_DATASET].getSimpleExtentDims(particles_dims_current, NULL);
+    H5Sget_simple_extent_dims(_open_out_dataspaces[PARTICLES_DATASET], particles_dims_current, NULL);
+    // .getSimpleExtentDims(particles_dims_current, NULL);
 
     // Make a note of the first index:
     next_extents.first = particles_dims_current[0];
@@ -148,7 +158,8 @@ namespace larcv3{
 
 
     // Extend the dataset to accomodate the new data
-    _open_out_datasets[PARTICLES_DATASET].extend(particles_size);
+    H5Dset_extent(_open_out_datasets[PARTICLES_DATASET], particles_size);
+    // .extend(particles_size);
 
 
     /////////////////////////////////////////////////////////
@@ -157,19 +168,35 @@ namespace larcv3{
 
     // Select as a hyperslab the last section of data for writing:
     // Need to reopen the dataspace after extension:
-    _open_out_dataspaces[PARTICLES_DATASET] = _open_out_datasets[PARTICLES_DATASET].getSpace();
-    _open_out_dataspaces[PARTICLES_DATASET].selectHyperslab(H5S_SELECT_SET, 
-        particles_slab_dims, particles_dims_current);
+    _open_out_dataspaces[PARTICLES_DATASET] = H5Dget_space(_open_out_datasets[PARTICLES_DATASET]);
+
+    H5Sselect_hyperslab(_open_out_dataspaces[PARTICLES_DATASET], 
+      H5S_SELECT_SET, 
+      particles_dims_current, // start
+      NULL ,                  // stride
+      particles_slab_dims,    // count 
+      NULL                    // block
+      );
+
 
     // Define memory space:
-    H5::DataSpace particles_memspace(1, particles_slab_dims);
+    // H5::DataSpace particles_memspace(1, particles_slab_dims);
+    hid_t particles_memspace = H5Screate_simple(1, particles_slab_dims, NULL);
 
+    // Transfer property list, default:
+    hid_t xfer_plist_id = H5Pcreate(H5P_DATASET_XFER);
 
     // Write the new data
-    _open_out_datasets[PARTICLES_DATASET].write(&(_part_v[0]), *_data_types[PARTICLES_DATASET], 
-        particles_memspace, _open_out_dataspaces[PARTICLES_DATASET]);
+    // _open_out_datasets[PARTICLES_DATASET].write(&(_part_v[0]), _data_types[PARTICLES_DATASET], 
+        // particles_memspace, _open_out_dataspaces[PARTICLES_DATASET]);
 
-
+    H5Dwrite(_open_out_datasets[PARTICLES_DATASET],   // dataset_id,
+             _data_types[PARTICLES_DATASET],          // hit_t mem_type_id, 
+             particles_memspace,                      // hid_t mem_space_id, 
+             _open_out_dataspaces[PARTICLES_DATASET], //hid_t file_space_id, 
+             xfer_plist_id,                           //hid_t xfer_plist_id, 
+             &(_part_v[0])                            // const void * buf 
+           );
 
     /////////////////////////////////////////////////////////
     // Get the extents dataset
@@ -182,8 +209,8 @@ namespace larcv3{
 
 
     // Get the dataset current size
-    hsize_t extents_dims_current[1];
-    _open_out_dataspaces[EXTENTS_DATASET].getSimpleExtentDims(extents_dims_current, NULL);
+     hsize_t extents_dims_current[1];
+    H5Sget_simple_extent_dims(_open_out_dataspaces[EXTENTS_DATASET], extents_dims_current, NULL);
 
     // Create a dimension for the data to add (which is the hyperslab data)
     hsize_t extents_slab_dims[1];
@@ -195,24 +222,43 @@ namespace larcv3{
     extents_size[0] = extents_dims_current[0] + extents_slab_dims[0];
 
     // Extend the dataset to accomodate the new data
-    _open_out_datasets[EXTENTS_DATASET].extend(extents_size);
+    H5Dset_extent(_open_out_datasets[EXTENTS_DATASET], extents_size);
 
 
     /////////////////////////////////////////////////////////
     // Write the new extents entry to the dataset
     /////////////////////////////////////////////////////////
 
-    // Now, select as a hyperslab the last section of data for writing:
-    _open_out_dataspaces[EXTENTS_DATASET] = _open_out_datasets[EXTENTS_DATASET].getSpace();
-    _open_out_dataspaces[EXTENTS_DATASET].selectHyperslab(H5S_SELECT_SET, extents_slab_dims, extents_dims_current);
+
+
+    // Select as a hyperslab the last section of data for writing:
+    // Need to reopen the dataspace after extension:
+    _open_out_dataspaces[EXTENTS_DATASET] = H5Dget_space(_open_out_datasets[EXTENTS_DATASET]);
+
+    H5Sselect_hyperslab(_open_out_dataspaces[EXTENTS_DATASET], 
+      H5S_SELECT_SET, 
+      extents_dims_current, // start
+      NULL ,  // stride
+      extents_slab_dims, //count 
+      NULL // block
+      );
+
 
     // Define memory space:
-    H5::DataSpace extents_memspace(1, extents_slab_dims);
-
+    // H5::DataSpace particles_memspace(1, particles_slab_dims);
+    hid_t extents_memspace = H5Screate_simple(1, extents_slab_dims, NULL);
 
     // Write the new data
-    _open_out_datasets[EXTENTS_DATASET].write(&(next_extents), 
-        *_data_types[EXTENTS_DATASET], extents_memspace, _open_out_dataspaces[EXTENTS_DATASET]);
+    // _open_out_datasets[PARTICLES_DATASET].write(&(_part_v[0]), _data_types[PARTICLES_DATASET], 
+        // extents_memspace, _open_out_dataspaces[PARTICLES_DATASET]);
+
+    H5Dwrite(_open_out_datasets[EXTENTS_DATASET], // dataset_id,
+             _data_types[EXTENTS_DATASET], // hit_t mem_type_id, 
+             extents_memspace, // hid_t mem_space_id, 
+             _open_out_dataspaces[EXTENTS_DATASET], //hid_t file_space_id, 
+             xfer_plist_id, //hid_t xfer_plist_id, 
+             &(next_extents) // const void * buf 
+             );
 
 
     /////////////////////////////////////////////////////////
@@ -223,13 +269,13 @@ namespace larcv3{
     return;
   }
 
-  void EventParticle::initialize(H5::Group * group, uint compression){
+  void EventParticle::initialize(hid_t group, uint compression){
 
     // Initialize is ONLY meant to be called on an empty group.  So, verify this group 
     // is empty:
 
-    if (group -> getNumObjs() != 0){
-      LARCV_CRITICAL() << "Attempt to initialize non empty particle group " << group->fromClass() << std::endl;
+    if (get_num_objects(group) != 0){
+      LARCV_CRITICAL() << "Attempt to initialize non empty particle group " << group << std::endl;
       throw larbys();
     }
 
@@ -250,21 +296,34 @@ namespace larcv3{
     hsize_t extents_maxsize_dim[]  = {H5S_UNLIMITED};
 
     // Create a dataspace 
-    H5::DataSpace extents_dataspace(1, extents_starting_dim, extents_maxsize_dim);
+    hid_t extents_dataspace = H5Screate_simple(1, extents_starting_dim, extents_maxsize_dim);
+    // H5::DataSpace extents_dataspace(1, extents_starting_dim, extents_maxsize_dim);
 
     /*
      * Modify dataset creation properties, i.e. enable chunking.
      */
-    H5::DSetCreatPropList extents_cparms;
+    hid_t extents_cparms = H5Pcreate( H5P_DATASET_CREATE );
+    // H5::DSetCreatPropList extents_cparms;
     hsize_t      extents_chunk_dims[1] ={PARTICLE_EXTENTS_CHUNK_SIZE};
-    extents_cparms.setChunk( 1, extents_chunk_dims );
+    H5Pset_chunk(extents_cparms, 1, extents_chunk_dims );
     if (compression){
-      extents_cparms.setDeflate(compression);
+      H5Pset_deflate(extents_cparms, compression);
+      // extents_cparms.setDeflate(compression);
     }
 
+
     // Create the extents dataset:
-    H5::DataSet extents_ds = group->createDataSet("extents", 
-        *_data_types[EXTENTS_DATASET], extents_dataspace, extents_cparms);
+    H5Dcreate(
+      group,                        // hid_t loc_id  IN: Location identifier
+      "extents",                    // const char *name      IN: Dataset name
+      _data_types[EXTENTS_DATASET], // hid_t dtype_id  IN: Datatype identifier
+      extents_dataspace,            // hid_t space_id  IN: Dataspace identifier
+      NULL,                         // hid_t lcpl_id IN: Link creation property list
+      extents_cparms,               // hid_t dcpl_id IN: Dataset creation property list
+      NULL                          // hid_t dapl_id IN: Dataset access property list
+    );
+    // H5::DataSet extents_ds = group->createDataSet("extents", 
+        // *_data_types[EXTENTS_DATASET], extents_dataspace, extents_cparms);
 
 
     /////////////////////////////////////////////////////////
@@ -279,26 +338,33 @@ namespace larcv3{
     hsize_t particle_maxsize_dim[]  = {H5S_UNLIMITED};
 
     // Create a dataspace 
-    H5::DataSpace particle_dataspace(1, particle_starting_dim, particle_maxsize_dim);
-
+    hid_t particle_dataspace = H5Screate_simple(1, particle_starting_dim, particle_maxsize_dim);
     /*
      * Modify dataset creation properties, i.e. enable chunking.
      */
-    H5::DSetCreatPropList particle_cparms;
-    hsize_t      particle_chunk_dims[1] ={PARTICLE_DATA_CHUNK_SIZE};
-    particle_cparms.setChunk( 1, particle_chunk_dims );
+
+    hid_t   particle_cparms = H5Pcreate( H5P_DATASET_CREATE );
+    hsize_t particle_chunk_dims[1] ={PARTICLE_DATA_CHUNK_SIZE};
+    
+    H5Pset_chunk(particle_cparms, 1, particle_chunk_dims );
     if (compression){
-      particle_cparms.setDeflate(compression);
+      H5Pset_deflate(particle_cparms, compression);
     }
 
     // Create the extents dataset:
-    H5::DataSet particle_ds = group->createDataSet("particles", 
-        *_data_types[PARTICLES_DATASET], particle_dataspace, particle_cparms);
-
+    H5Dcreate(
+      group,                          // hid_t loc_id  IN: Location identifier
+      "particles",                    // const char *name      IN: Dataset name
+      _data_types[PARTICLES_DATASET], // hid_t dtype_id  IN: Datatype identifier
+      particle_dataspace,             // hid_t space_id  IN: Dataspace identifier
+      NULL,                           // hid_t lcpl_id IN: Link creation property list
+      particle_cparms,                // hid_t dcpl_id IN: Dataset creation property list
+      NULL                            // hid_t dapl_id IN: Dataset access property list
+      );
 
   }
 
-  void EventParticle::deserialize(H5::Group * group, size_t entry, bool reopen_groups){
+  void EventParticle::deserialize(hid_t group, size_t entry, bool reopen_groups){
     
     // Deserialization is, in some ways, easier than serialization.
     // We just have to read data from the file, and wrap it into an std::vector.
@@ -347,16 +413,34 @@ namespace larcv3{
     /////////////////////////////////////////////////////////
 
     // Now, select as a hyperslab the last section of data for writing:
-    // extents_dataspace = extents_dataset.getSpace();
-    _open_in_dataspaces[EXTENTS_DATASET].selectHyperslab(H5S_SELECT_SET, extents_slab_dims, extents_offset);
+    
+    H5Sselect_hyperslab(_open_in_dataspaces[EXTENTS_DATASET], 
+      H5S_SELECT_SET, 
+      extents_offset, // start
+      NULL ,  // stride
+      extents_slab_dims, //count 
+      NULL // block
+      );
 
     // Define memory space:
-    H5::DataSpace extents_memspace(1, extents_slab_dims);
+    hid_t extents_memspace = H5Screate_simple(1, extents_slab_dims, NULL);
 
     Extents_t input_extents;
     // Write the new data
-    _open_in_datasets[EXTENTS_DATASET].read(&(input_extents), *_data_types[EXTENTS_DATASET],
-      extents_memspace, _open_in_dataspaces[EXTENTS_DATASET]);
+    // _open_in_datasets[EXTENTS_DATASET].read(&(input_extents), *_data_types[EXTENTS_DATASET],
+      // extents_memspace, _open_in_dataspaces[EXTENTS_DATASET]);
+    
+    // Transfer property list, default
+    hid_t xfer_plist_id = H5Pcreate(H5P_DATASET_XFER);
+
+    H5Dread(
+      _open_in_datasets[EXTENTS_DATASET],    // hid_t dataset_id  IN: Identifier of the dataset read from.
+      _data_types[EXTENTS_DATASET],          // hid_t mem_type_id IN: Identifier of the memory datatype.
+      extents_memspace,                      // hid_t mem_space_id  IN: Identifier of the memory dataspace.
+      _open_in_dataspaces[EXTENTS_DATASET],  // hid_t file_space_id IN: Identifier of the dataset's dataspace in the file.
+      xfer_plist_id,                         // hid_t xfer_plist_id     IN: Identifier of a transfer property list for this I/O operation.
+      &(input_extents)                       // void * buf  OUT: Buffer to receive data read from file.
+    );
 
     // std::cout << " Extents start: " << input_extents.first << ", end: "
     //           << input_extents.first + input_extents.n << std::endl;
@@ -383,18 +467,36 @@ namespace larcv3{
 
     // Now, select as a hyperslab the last section of data for writing:
     // extents_dataspace = extents_dataset.getSpace();
-    _open_in_dataspaces[PARTICLES_DATASET].selectHyperslab(H5S_SELECT_SET, particles_slab_dims, particles_offset);
+    // _open_in_dataspaces[PARTICLES_DATASET].selectHyperslab(H5S_SELECT_SET, particles_slab_dims, particles_offset);
 
+    H5Sselect_hyperslab(_open_in_dataspaces[PARTICLES_DATASET], 
+      H5S_SELECT_SET, 
+      particles_offset,    // start
+      NULL ,               // stride
+      particles_slab_dims, //count 
+      NULL                 // block
+      );
 
-    H5::DataSpace particles_memspace(1, particles_slab_dims);
+    // H5::DataSpace particles_memspace(1, particles_slab_dims);
+
+    // Define memory space:
+    hid_t particles_memspace = H5Screate_simple(1, particles_slab_dims, NULL);
 
     // Reserve space for reading in particles:
     _part_v.resize(input_extents.n);
 
-    _open_in_datasets[PARTICLES_DATASET].read(&(_part_v[0]), *_data_types[PARTICLES_DATASET],
-        particles_memspace, _open_in_dataspaces[PARTICLES_DATASET]);
+    // _open_in_datasets[PARTICLES_DATASET].read(&(_part_v[0]), *_data_types[PARTICLES_DATASET],
+    //     particles_memspace, _open_in_dataspaces[PARTICLES_DATASET]);
 
     
+    H5Dread(
+      _open_in_datasets[PARTICLES_DATASET],    // hid_t dataset_id  IN: Identifier of the dataset read from.
+      _data_types[PARTICLES_DATASET],          // hid_t mem_type_id IN: Identifier of the memory datatype.
+      particles_memspace,                      // hid_t mem_space_id  IN: Identifier of the memory dataspace.
+      _open_in_dataspaces[PARTICLES_DATASET],  // hid_t file_space_id IN: Identifier of the dataset's dataspace in the file.
+      xfer_plist_id,                         // hid_t xfer_plist_id     IN: Identifier of a transfer property list for this I/O operation.
+      &(_part_v[0])                       // void * buf  OUT: Buffer to receive data read from file.
+    );
 
     return;
   }

--- a/src/larcv3/core/dataformat/EventParticle.h
+++ b/src/larcv3/core/dataformat/EventParticle.h
@@ -50,10 +50,11 @@ namespace larcv3 {
 
 // #ifndef SWIG
     /// Data clear method
-    void clear();
-    void initialize (H5::Group * group, uint compression);
-    void serialize  (H5::Group * group);
-    void deserialize(H5::Group * group, size_t entry, bool reopen_groups=false);
+    void clear      ();
+    void initialize (hid_t group, uint compression);
+    void serialize  (hid_t group);
+    void deserialize(hid_t group, size_t entry, bool reopen_groups=false);
+    void finalize   ();
 // #endif
 
     static EventParticle * to_particle(EventBase * e){
@@ -62,8 +63,8 @@ namespace larcv3 {
 
   private:
 
-    void open_in_datasets(H5::Group * group);
-    void open_out_datasets(H5::Group * group);    
+    void open_in_datasets(hid_t group);
+    void open_out_datasets(hid_t group);    
 
     std::vector<larcv3::Particle> _part_v; ///< a collection of particles (index maintained)
 

--- a/src/larcv3/core/dataformat/EventSparseCluster.h
+++ b/src/larcv3/core/dataformat/EventSparseCluster.h
@@ -65,9 +65,10 @@ namespace larcv3 {
 
 
     // IO functions:
-    void initialize (H5::Group * group, uint compression);
-    void serialize  (H5::Group * group);
-    void deserialize(H5::Group * group, size_t entry, bool reopen_groups=false);
+    void initialize (hid_t group, uint compression);
+    void serialize  (hid_t group);
+    void deserialize(hid_t group, size_t entry, bool reopen_groups=false);
+    void finalize   ();
 
 
     static EventSparseCluster * to_sparse_cluster(EventBase * e){
@@ -75,8 +76,8 @@ namespace larcv3 {
     }
 
   private:
-    void open_in_datasets(H5::Group * group);
-    void open_out_datasets(H5::Group * group);
+    void open_in_datasets(hid_t group);
+    void open_out_datasets(hid_t group);
     std::vector<larcv3::SparseCluster<dimension> > _cluster_v;
 
   };

--- a/src/larcv3/core/dataformat/EventSparseTensor.h
+++ b/src/larcv3/core/dataformat/EventSparseTensor.h
@@ -65,18 +65,18 @@ namespace larcv3 {
 
 
     // IO functions:
-    void initialize (H5::Group * group, uint compression);
-    void serialize  (H5::Group * group);
-    void deserialize(H5::Group * group, size_t entry, bool reopen_groups=false);
-
+    void initialize (hid_t group, uint compression);
+    void serialize  (hid_t group);
+    void deserialize(hid_t group, size_t entry, bool reopen_groups=false);
+    void finalize   ();
 
     static EventSparseTensor * to_sparse_tensor(EventBase * e){
       return (EventSparseTensor *) e;
     }
 
   private:
-    void open_in_datasets(H5::Group * group);
-    void open_out_datasets(H5::Group * group);
+    void open_in_datasets(hid_t group);
+    void open_out_datasets(hid_t group);
     
     std::vector<larcv3::SparseTensor<dimension> >  _tensor_v;
 

--- a/src/larcv3/core/dataformat/EventTensor.h
+++ b/src/larcv3/core/dataformat/EventTensor.h
@@ -51,10 +51,11 @@ namespace larcv3 {
     void move(std::vector<larcv3::Tensor<dimension>>& image_v)
     { image_v = std::move(_image_v); }
     
-    void initialize (H5::Group * group, uint compression);
-    void serialize  (H5::Group * group);
-    void deserialize(H5::Group * group, size_t entry, bool reopen_groups=false);
-
+    void initialize (hid_t group, uint compression);
+    void serialize  (hid_t group);
+    void deserialize(hid_t group, size_t entry, bool reopen_groups=false);
+    void finalize   ();
+    
     /// For backward compatibility
     static EventTensor * to_image2d(EventBase * e){
       return to_tensor(e);
@@ -65,8 +66,8 @@ namespace larcv3 {
     }
     
   private:
-    void open_in_datasets(H5::Group * group);
-    void open_out_datasets(H5::Group * group);
+    void open_in_datasets(hid_t group);
+    void open_out_datasets(hid_t group);
 
     std::vector<larcv3::Tensor<dimension>> _image_v;
 

--- a/src/larcv3/core/dataformat/IOManager.cxx
+++ b/src/larcv3/core/dataformat/IOManager.cxx
@@ -1059,41 +1059,44 @@ void IOManager::set_id() {
   // }
 }
 
-int IOManager::what_is_open(hid_t fid) {
-  ssize_t cnt;
-  int howmany;
-  H5I_type_t ot;
-  hid_t anobj, *objs;
-  char name[1024];
-  herr_t status;
+// int IOManager::what_is_open(hid_t fid) {
+//   ssize_t cnt;
+//   int howmany;
+//   H5I_type_t ot;
+//   hid_t anobj;
+//   std::vector<hid_t> objs;
+//   char name[1024];
+//   herr_t status;
 
-  cnt = H5Fget_obj_count(fid, H5F_OBJ_ALL);
+//   cnt = H5Fget_obj_count(fid, H5F_OBJ_ALL);
 
-  if (cnt <= 0) return cnt;
+//   if (cnt <= 0) return cnt;
 
-  LARCV_DEBUG() << cnt << "object(s) are open." << std::endl;
+//   LARCV_DEBUG() << cnt << "object(s) are open." << std::endl;
 
-  objs = (hid_t *) malloc(cnt * sizeof(hid_t));
+//   objs.resize(cnt);
+//   // objs = (hid_t *) malloc(cnt * sizeof(hid_t));
 
-  howmany = H5Fget_obj_ids(fid, H5F_OBJ_ALL, cnt, objs);
+//   howmany = H5Fget_obj_ids(fid, H5F_OBJ_ALL, cnt, &(objs[0]));
 
-  printf("open objects:\n");
+//   printf("open objects:\n");
 
-  for (int i = 0; i < howmany; i++ ) {
-    anobj = *objs++;
-    ot = H5Iget_type(anobj);
-    status = H5Iget_name(anobj, name, 1024);
-    LARCV_DEBUG() << "Open object: " << i << " type " << ot << ", name " << name << std::endl;;
-  }
+//   for (int i = 0; i < howmany; i++ ) {
+//     anobj = objs[i];
+//     ot = H5Iget_type(anobj);
+//     status = H5Iget_name(anobj, name, 1024);
+//     LARCV_DEBUG() << "Open object: " << i << " type " << ot << ", name " << name << std::endl;;
+//   }
          
-  return howmany;
-}
+//   return howmany;
+// }
 
 int IOManager::close_all_objects(hid_t fid) {
   ssize_t cnt;
   int howmany;
   H5I_type_t ot;
-  hid_t anobj, *objs;
+  hid_t anobj;
+  std::vector<hid_t> objs;
   char name[1024];
   herr_t status;
 
@@ -1101,12 +1104,14 @@ int IOManager::close_all_objects(hid_t fid) {
 
   if (cnt <= 0) return cnt;
 
-  objs = (hid_t *) malloc(cnt * sizeof(hid_t));
+  objs.resize(cnt);
+  // objs = (hid_t *) malloc(cnt * sizeof(hid_t));
 
-  howmany = H5Fget_obj_ids(fid, H5F_OBJ_ALL, cnt, objs);
+  // howmany = H5Fget_obj_ids(fid, H5F_OBJ_ALL, cnt, objs);
+  howmany = H5Fget_obj_ids(fid, H5F_OBJ_ALL, cnt, &(objs[0]));
 
   for (int i = 0; i < howmany; i++ ) {
-    anobj = *objs++;
+    anobj = objs[i];
     ot = H5Iget_type(anobj);
     status = H5Iget_name(anobj, name, 1024);
     LARCV_INFO() << "Closing: " << i << " type " << ot << ", name " << name << std::endl;;
@@ -1138,7 +1143,7 @@ void IOManager::finalize() {
     //   }
     // }
 
-    what_is_open (_out_file);
+    // what_is_open (_out_file);
     close_all_objects(_out_file);
 
     LARCV_NORMAL() << "Closing output file" << std::endl;

--- a/src/larcv3/core/dataformat/IOManager.cxx
+++ b/src/larcv3/core/dataformat/IOManager.cxx
@@ -34,7 +34,6 @@ IOManager::IOManager(IOMode_t mode, std::string name)
       _in_file_v(),
       _in_dir_v(),
       _key_list(),
-      _fapl(H5::FileAccPropList::DEFAULT),
       _product_ctr(0),
       _product_ptr_v(),
       _product_type_v(),
@@ -42,6 +41,8 @@ IOManager::IOManager(IOMode_t mode, std::string name)
       _h5_core_driver(false),
       _force_reopen_groups(false) {
   reset();
+  _fapl = H5Pcreate(H5P_FILE_ACCESS);
+  xfer_plist_id = H5Pcreate(H5P_DATASET_XFER);
   _event_id_datatype = larcv3::EventID::get_datatype();
 }
 
@@ -111,7 +112,7 @@ void IOManager::configure(const PSet& cfg) {
     LARCV_INFO() << "File will be stored entirely on memory." << std::endl;
     // 1024 is number of bytes to increment each time more memory is needed;
     //'false': do not write contents to disk when the file is closed
-    _fapl.setCore(1024, false);
+    H5Pset_fapl_core(_fapl, 1024, false);
   }
 
   // Figure out input files
@@ -226,11 +227,27 @@ bool IOManager::initialize(int color) {
     if (_out_file_name.empty()) throw larbys("Must set output file name!");
     LARCV_INFO() << "Opening an output file: " << _out_file_name << std::endl;
 
-    _out_file = H5::H5File(_out_file_name.c_str(), H5F_ACC_TRUNC);
+    // Using default file creation properties, default file access properties
+    _out_file = H5Fcreate(_out_file_name.c_str(), H5F_ACC_TRUNC, H5P_DEFAULT, H5P_DEFAULT);
 
     // Create the top level groups in the output file.
-    _out_file.createGroup("/Events");
-    _out_file.createGroup("/Data");
+    H5Gcreate(
+      _out_file,   // hid_t loc_id  IN: File or group identifier
+      "/Events",   // const char *name      IN: Absolute or relative name of the link to the new group
+      H5P_DEFAULT, // hid_t lcpl_id IN: Link creation property list identifier
+      H5P_DEFAULT, // hid_t gcpl_id IN: Group creation property list identifier
+      H5P_DEFAULT  // hid_t gapl_id IN: Group access property list identifier 
+                      // (No group access properties have been implemented at this time; use H5P_DEFAULT.)
+    );
+    H5Gcreate(
+      _out_file,   // hid_t loc_id  IN: File or group identifier
+      "/Data",     // const char *name      IN: Absolute or relative name of the link to the new group
+      H5P_DEFAULT, // hid_t lcpl_id IN: Link creation property list identifier
+      H5P_DEFAULT, // hid_t gcpl_id IN: Group creation property list identifier
+      H5P_DEFAULT  // hid_t gapl_id IN: Group access property list identifier 
+                      // (No group access properties have been implemented at this time; use H5P_DEFAULT.)
+    );
+
 
     // Create the output EventID dataset:
     hsize_t starting_dim[] = {0};
@@ -238,18 +255,25 @@ bool IOManager::initialize(int color) {
 
     // Create a dataspace of rank 1, starting with 0 entries as above, growing
     // to unlimited entries.
-    H5::DataSpace dataspace(1, starting_dim, maxsize_dim);
+    hid_t dataspace = H5Screate_simple(1, starting_dim, maxsize_dim);
     LARCV_DEBUG() << "EventID Dataspace Created for new file" << std::endl;
     /*
      * Modify dataset creation properties, i.e. enable chunking.
      */
-    H5::DSetCreatPropList cparams;
-    hsize_t chunk_dims[1] = {EVENT_ID_CHUNK_SIZE};
-    cparams.setChunk(1, chunk_dims);
-    cparams.setDeflate(_compression_override);
+    hid_t cparams = H5Pcreate( H5P_DATASET_CREATE );
+    hsize_t      extents_chunk_dims[1] ={EVENT_ID_CHUNK_SIZE};
+    H5Pset_chunk(cparams, 1, extents_chunk_dims );
+    H5Pset_deflate(cparams, _compression_override);
 
-    _out_event_id_ds = _out_file.createDataSet(
-        "Events/event_id", larcv3::EventID::get_datatype(), dataspace, cparams);
+    _out_event_id_ds = H5Dcreate(
+        _out_file,                       // hid_t loc_id  IN: Location identifier
+        "Events/event_id",               // const char *name      IN: Dataset name
+        larcv3::EventID::get_datatype(), // hid_t dtype_id  IN: Datatype identifier
+        dataspace,                       // hid_t space_id  IN: Dataspace identifier
+        H5P_DEFAULT,                     // hid_t lcpl_id IN: Link creation property list
+        cparams,                         // hid_t dcpl_id IN: Dataset creation property list
+        H5P_DEFAULT                      // hid_t dapl_id IN: Dataset access property list
+      );
 
   }
 
@@ -304,6 +328,7 @@ bool IOManager::initialize(int color) {
   _out_index = 0;
   _prepared = true;
   __ioman_mtx.unlock();
+
 
   return true;
 }
@@ -394,8 +419,15 @@ size_t IOManager::register_producer(const ProducerName_t& name) {
       if (_out_group_v.size() <= id){
         _out_group_v.resize(id + 1);
       }
-      _out_group_v[id] = _out_file.createGroup(group_loc.c_str());
-      _product_ptr_v[id]->initialize(&_out_group_v[id], _compression_override);
+      _out_group_v[id] = H5Gcreate(      
+        _out_file,           // hid_t loc_id  IN: File or group identifier
+        group_loc.c_str(),   // const char *name      IN: Absolute or relative name of the link to the new group
+        H5P_DEFAULT,         // hid_t lcpl_id IN: Link creation property list identifier
+        H5P_DEFAULT,         // hid_t gcpl_id IN: Group creation property list identifier
+        H5P_DEFAULT          // hid_t gapl_id IN: Group access property list identifier 
+                               // (No group access properties have been implemented at this time; use H5P_DEFAULT.));
+      );
+      _product_ptr_v[id]->initialize(_out_group_v[id], _compression_override);
       LARCV_DEBUG() << "Created Group " << group_loc << " @ " << &_out_group_v[id] << std::endl;
     }
     else{
@@ -438,8 +470,6 @@ void IOManager::prepare_input() {
   _in_entries_total = 0;
   // Index of currently active file - start at file 0
   _in_active_file_index = 0;
-  // Currently open file:
-  // H5::H5File  _in_open_file;
   // the file is opened at the end of this function
 
   // List of total entries in input files?
@@ -454,8 +484,6 @@ void IOManager::prepare_input() {
     auto const& fname = _in_file_v[i_file];
     // auto const& dname = _in_dir_v[i_file];
 
-    // H5::H5File* fin;
-
     LARCV_NORMAL() << "Opening a file in READ mode: " << fname << std::endl;
     open_new_input_file(fname);
     read_current_event_id();
@@ -463,8 +491,8 @@ void IOManager::prepare_input() {
     // Each file has (or should have) two groups: "Data" and "Events"
 
     try {
-      H5::Group data = _in_open_file.openGroup("/Data");
-      H5::Group events = _in_open_file.openGroup("/Events");
+      hid_t data_group = H5Gopen(_in_open_file, "/Data", H5P_DEFAULT);
+      hid_t events_group = H5Gopen(_in_open_file, "/Events", H5P_DEFAULT);
     } catch (...) {
       LARCV_CRITICAL() << "File " << fname
                        << " does not appear to be a larcv3 file, exiting."
@@ -473,18 +501,21 @@ void IOManager::prepare_input() {
     }
 
     // Re-open those groups after the check
-    H5::Group data = _in_open_file.openGroup("/Data");
-    H5::Group events = _in_open_file.openGroup("/Events");
+    hid_t data_group = H5Gopen(_in_open_file, "/Data", H5P_DEFAULT);
+    hid_t events_group = H5Gopen(_in_open_file, "/Events", H5P_DEFAULT);
 
     // Vist the extents group and determine how many events are present:
 
-    H5::DataSet extents = events.openDataSet("event_id");
+    hid_t dapl = H5Pcreate(H5P_DATASET_ACCESS);
+
+    hid_t extents_dataset = H5Dopen(events_group, "event_id", dapl);
     // Number of objects:
     hsize_t dims_current[1];
-    extents.getSpace().getSimpleExtentDims(dims_current, NULL);
+    hid_t extents_space = H5Dget_space(extents_dataset);
+    H5Sget_simple_extent_dims(extents_space, dims_current, NULL );
     // Number of entries is:
 
-    LARCV_INFO() << "File " << fname << " has " << dims_current[0] << " entries"
+    LARCV_NORMAL() << "File " << fname << " has " << dims_current[0] << " entries"
                  << std::endl;
 
     // Append the number of events:
@@ -494,10 +525,15 @@ void IOManager::prepare_input() {
 
     // Next, visit the available groups and see what producers are available.
     std::set<std::string> processed_object;
-    for (size_t i_obj = 0; i_obj < data.getNumObjs(); ++i_obj) {
+
+    hsize_t  num_objects[1] = {0};
+    H5Gget_num_objs(data_group, num_objects);
+
+    for (size_t i_obj = 0; i_obj < num_objects[0]; ++i_obj) {
       char temp_name[128];
       // std::string obj_name =
-      int real_size = data.getObjnameByIdx(i_obj, temp_name, 128);
+      H5Gget_objname_by_idx(data_group, i_obj, temp_name,128); 
+      // int real_size = data_group.getObjnameByIdx(i_obj, temp_name, 128);
       std::string obj_name(temp_name);
       processed_object.insert(obj_name);
       char c[2] = "_";
@@ -574,9 +610,11 @@ void IOManager::prepare_input() {
 
 void IOManager::open_new_input_file(std::string filename){
 
+  // Close the currently open file if it is open:
+  // H5Fclose(_in_open_file);
 
   try{
-    _in_open_file = H5::H5File(filename.c_str(), H5F_ACC_RDONLY, H5::FileCreatPropList::DEFAULT, _fapl);
+    _in_open_file = H5Fopen(filename.c_str(), H5F_ACC_RDONLY, _fapl);
   }
   catch ( ... ) {
     LARCV_CRITICAL() << "Open attempt failed for a file: " << filename
@@ -584,8 +622,11 @@ void IOManager::open_new_input_file(std::string filename){
     throw larbys();
   }
 
-  _active_in_event_id_dataset   = _in_open_file.openGroup("Events").openDataSet("event_id");
-  _active_in_event_id_dataspace = _active_in_event_id_dataset.getSpace();
+  hid_t group = H5Gopen(_in_open_file, "Events", H5P_DEFAULT);
+  
+  hid_t dapl = H5Pcreate(H5P_DATASET_ACCESS);
+  _active_in_event_id_dataset   = H5Dopen(group, "event_id", dapl);
+  _active_in_event_id_dataspace = H5Dget_space(_active_in_event_id_dataset);
 
 }
 
@@ -637,12 +678,7 @@ bool IOManager::read_entry(const size_t index, bool force_reload) {
     if (_this_file_index != _in_active_file_index) {
       // Open a new file for reading:
       _in_active_file_index = _this_file_index;
-      _in_open_file =
-          H5::H5File(_in_file_v[_in_active_file_index].c_str(), H5F_ACC_RDONLY);
-
-      _active_in_event_id_dataset   = _in_open_file.openGroup("Events").openDataSet("event_id");
-      _active_in_event_id_dataspace = _active_in_event_id_dataset.getSpace();
-
+      open_new_input_file(_in_file_v[_in_active_file_index]);
 
       LARCV_INFO() << "Opening new file for continued event reading"
                      << std::endl;
@@ -663,34 +699,6 @@ bool IOManager::read_entry(const size_t index, bool force_reload) {
       }
     }
 
-    // // Now, we can open the events folder and figure out what's what.
-    // // H5::DataSet events_dataset =
-    //     // _in_open_file.openGroup("Events").openDataSet("event_id");
-    // // H5::DataSpace events_dataspace = events_dataset.getSpace();
-
-    // hsize_t events_slab_dims[1];
-    // events_slab_dims[0] = 1;
-
-    // hsize_t events_offset[1];
-    // // Calculate the _current_offset based on requested index + _current_offset
-    // // for this file
-    // events_offset[0] = _in_index - _current_offset;
-
-    // _active_in_event_id_dataspace.selectHyperslab(H5S_SELECT_SET, events_slab_dims,
-    //                                  events_offset);
-
-    // // Define memory space:
-    // H5::DataSpace events_memspace(1, events_slab_dims);
-
-    // EventID input_event_id;
-    // // Write the new data
-    // _active_in_event_id_dataset.read(&(input_event_id), _event_id_datatype,
-    //                     events_memspace, _active_in_event_id_dataspace);
-    // std::cout << "Active in event id for index " << index << ": " << input_event_id.event_key() << std::endl;
-    // _event_id = input_event_id;
-
-    // _in_open_file
-    // Open the right file, if necessary
   }
   LARCV_DEBUG() << "Current input group index: " << _in_index << std::endl;
 
@@ -701,9 +709,6 @@ bool IOManager::read_entry(const size_t index, bool force_reload) {
 
 void IOManager::read_current_event_id(){
       // Now, we can open the events folder and figure out what's what.
-    // H5::DataSet events_dataset =
-        // _in_open_file.openGroup("Events").openDataSet("event_id");
-    // H5::DataSpace events_dataspace = events_dataset.getSpace();
 
     hsize_t events_slab_dims[1];
     events_slab_dims[0] = 1;
@@ -713,16 +718,28 @@ void IOManager::read_current_event_id(){
     // for this file
     events_offset[0] = _in_index - _current_offset;
 
-    _active_in_event_id_dataspace.selectHyperslab(H5S_SELECT_SET, events_slab_dims,
-                                     events_offset);
+    H5Sselect_hyperslab(_active_in_event_id_dataspace, 
+      H5S_SELECT_SET, 
+      events_offset,    // start
+      NULL ,            // stride
+      events_slab_dims, //count 
+      NULL              // block
+      );
 
+    
     // Define memory space:
-    H5::DataSpace events_memspace(1, events_slab_dims);
+    hid_t events_memspace = H5Screate_simple(1, events_slab_dims, NULL);
 
     EventID input_event_id;
-    // Write the new data
-    _active_in_event_id_dataset.read(&(input_event_id), _event_id_datatype,
-                        events_memspace, _active_in_event_id_dataspace);
+    // Read the  data
+    H5Dread(
+      _active_in_event_id_dataset,   // hid_t dataset_id  IN: Identifier of the dataset read from.
+      _event_id_datatype,            // hid_t mem_type_id IN: Identifier of the memory datatype.
+      events_memspace,               // hid_t mem_space_id  IN: Identifier of the memory dataspace.
+      _active_in_event_id_dataspace, // hid_t file_space_id IN: Identifier of the dataset's dataspace in the file.
+      xfer_plist_id,                 // hid_t xfer_plist_id     IN: Identifier of a transfer property list for this I/O operation.
+      &(input_event_id)              // void * buf  OUT: Buffer to receive data read from file.
+    );
     _event_id = input_event_id;
 }
 
@@ -772,10 +789,8 @@ bool IOManager::save_entry() {
     }
 
     for (size_t i = 0; i < _out_group_v.size(); ++i) {
-      auto t = &_out_group_v[i];
+      auto t = _out_group_v[i];
       auto& p = _product_ptr_v[i];
-
-      if (!t) break;
 
       p->serialize(t);
       p->clear();
@@ -806,7 +821,7 @@ bool IOManager::save_entry() {
 
     for (size_t i = 0; i < _store_id_bool.size(); ++i) {
       if (!_store_id_bool[i]) continue;
-      auto t = &_out_group_v[i];
+      auto  t = _out_group_v[i];
       auto& p = _product_ptr_v[i];
       LARCV_DEBUG() << "Saving id " << i << ": "
                     << _product_type_v[i] << " by "
@@ -831,13 +846,13 @@ void IOManager::append_event_id() {
   // First, we get information about the current status of the dataset:
   //////////////////////////////////////////////////////////////////
   // Get the dataspace of the event ID dataset:
-  H5::DataSpace dataspace = _out_event_id_ds.getSpace();
+  hid_t dataspace = H5Dget_space(_out_event_id_ds);
 
   // Get the dataset current size
   // The eventID table is exclusively rank-1
   hsize_t dims_current[1];
   // hsize_t * dims_current = new hsize_t[rank];
-  dataspace.getSimpleExtentDims(dims_current, NULL);
+  H5Sget_simple_extent_dims(dataspace, dims_current, NULL);
 
   // Create a dimension for the data to add (which is the hyperslab data)
   hsize_t dims_of_slab[1];
@@ -853,18 +868,33 @@ void IOManager::append_event_id() {
   size[0] = dims_current[0] + dims_of_slab[0];
 
   // Extend the dataset to accomodate the new data
-  _out_event_id_ds.extend(size);
+  H5Dset_extent(_out_event_id_ds, size);
 
   // Now, select as a hyperslab the last section of data for writing:
-  dataspace = _out_event_id_ds.getSpace();
-  dataspace.selectHyperslab(H5S_SELECT_SET, dims_of_slab, dims_current);
+  dataspace = H5Dget_space(_out_event_id_ds);
+
+  H5Sselect_hyperslab(dataspace, 
+    H5S_SELECT_SET, 
+    dims_current, // start
+    NULL ,        // stride
+    dims_of_slab, // count 
+    NULL          // block
+  );
 
   // Define memory space:
-  H5::DataSpace memspace(1, dims_of_slab);
+  hid_t memspace = H5Screate_simple(1, dims_of_slab, NULL);
+
 
   // Write the new data
-  _out_event_id_ds.write(&_event_id, EventID::get_datatype(), memspace,
-                         dataspace);
+  H5Dwrite(_out_event_id_ds,        // dataset_id,
+           _event_id_datatype,      // hit_t mem_type_id, 
+           memspace,                // hid_t mem_space_id, 
+           dataspace,               //hid_t file_space_id, 
+           xfer_plist_id,           //hid_t xfer_plist_id, 
+           &_event_id               // const void * buf 
+         );
+
+
 }
 
 void IOManager::clear_entry() {
@@ -961,26 +991,26 @@ EventBase* IOManager::get_data(const size_t id) {
     group_name = "Data/" + group_name + "_" + _producer_name_v[id] + "_group";
 
 
-    H5::Group group;
+    hid_t group;
     auto iter = _groups.find(group_name);
     if (iter == _groups.end() || _force_reopen_groups) {
-      group = _in_open_file.openGroup(group_name.c_str());
+      group = H5Gopen(_in_open_file, group_name.c_str(), H5P_DEFAULT);
+      // _in_open_file.openGroup(group_name.c_str());
       _groups[group_name] = group;
     } else {
       group = iter->second;
     }
 
     try {
-      LARCV_DEBUG() << "Calling deserialize for " << group_name << std::endl;
-      _product_ptr_v[id]->deserialize(&group, _in_index - _current_offset, _force_reopen_groups);
-      LARCV_DEBUG() << "Done deserialize for " << group_name << std::endl;
+      _product_ptr_v[id]->deserialize(group, _in_index - _current_offset, _force_reopen_groups);
       _product_status_v[id] = kInputFileRead;
     }
     catch (...){
       // When there is an error in deserialization, close the open input file gracefully:
       if(_io_mode != kWRITE){
         LARCV_CRITICAL() << "Exception caught in deserialization, closing input file gracefully" << std::endl;
-        _in_open_file.close();
+        H5Fclose(_in_open_file);
+        // _in_open_file.close();
       }
     }
   }
@@ -1050,7 +1080,7 @@ void IOManager::finalize() {
     //   }
     // }
     LARCV_NORMAL() << "Closing output file" << std::endl;
-    _out_file.close();
+    H5Fclose(_out_file);
   }
 
   LARCV_INFO() << "Deleting data pointers" << std::endl;

--- a/src/larcv3/core/dataformat/IOManager.h
+++ b/src/larcv3/core/dataformat/IOManager.h
@@ -149,7 +149,11 @@ namespace larcv3 {
 
     void append_event_id();
 
+    // Returns the number of open objects in file with id fid
+    int what_is_open(hid_t fid);
 
+    // Closes the objects currently open in file with id fid
+    int close_all_objects(hid_t fid);
 
     // The hdf5 model enforces the same number of entries per group,
     // since the entry list is defined per file.
@@ -198,6 +202,9 @@ namespace larcv3 {
 
     hid_t     _active_in_event_id_dataset;
     hid_t     _active_in_event_id_dataspace;
+
+    hid_t data_group;
+    hid_t events_group;
 
 
     // Parameters controlling the internals of an event.

--- a/src/larcv3/core/dataformat/IOManager.h
+++ b/src/larcv3/core/dataformat/IOManager.h
@@ -19,7 +19,7 @@
 #include <map>
 #include <set>
 
-#include "H5Cpp.h"
+#include "hdf5.h"
 
 #ifdef LARCV_MPI
 #include <mpi.h>
@@ -165,13 +165,13 @@ namespace larcv3 {
 
 
     // Parameters controlling output file large scale tracking:
-    // Name of the output file
-    H5::H5File  _out_file;
+    // ID of the output file:
+    hid_t  _out_file;
     // Current output index
     size_t      _out_index;
     // Total output entries
     size_t      _out_entries;
-    // Output file name:
+    // Name of the output file
     std::string _out_file_name;
 
     // Parameters controllign input file large scale tracking:
@@ -187,7 +187,7 @@ namespace larcv3 {
     // List of input directory names:
     std::vector<std::string>        _in_dir_v;
     // Currently open file:
-    H5::H5File  _in_open_file;
+    hid_t       _in_open_file;
     // List of total entries in input files
     std::vector<size_t>             _in_entries_v;
 
@@ -196,8 +196,8 @@ namespace larcv3 {
     EventID   _set_event_id;
     EventID   _last_event_id;
 
-    H5::DataSet    _active_in_event_id_dataset;
-    H5::DataSpace  _active_in_event_id_dataspace;
+    hid_t     _active_in_event_id_dataset;
+    hid_t     _active_in_event_id_dataspace;
 
 
     // Parameters controlling the internals of an event.
@@ -205,7 +205,7 @@ namespace larcv3 {
 
 
     // Output groups.  Since these are stored and need to be initialized, this is a member:
-    std::vector<H5::Group> _out_group_v;
+    std::vector<hid_t> _out_group_v;
 
 
     // Key list keeps track of the mapping from producer/product to an id:
@@ -215,9 +215,9 @@ namespace larcv3 {
 
 
     // Hold a copy of the file access property list:
-    H5::FileAccPropList _fapl;
+    hid_t  _fapl; //FileAccPropList 
 
-    std::map<std::string, H5::Group> _groups;
+    std::map<std::string, hid_t> _groups;
 
 
     // Keeping track of products and producers:
@@ -236,8 +236,9 @@ namespace larcv3 {
 
 
     // IOManager has to control the EventID dataset it's self for the output file.
-    H5::DataSet  _out_event_id_ds;
-    H5::DataType _event_id_datatype;
+    hid_t  _out_event_id_ds;  // dataset
+    hid_t _event_id_datatype; // datatype
+    hid_t xfer_plist_id;
 
     // Internal bookkeeping for when the input file switches:
     bool _force_reopen_groups;
@@ -257,3 +258,4 @@ namespace larcv3 {
 
 #endif
 /** @} */ // end of doxygen group
+    

--- a/src/larcv3/core/dataformat/IOManager.h
+++ b/src/larcv3/core/dataformat/IOManager.h
@@ -149,8 +149,8 @@ namespace larcv3 {
 
     void append_event_id();
 
-    // Returns the number of open objects in file with id fid
-    int what_is_open(hid_t fid);
+    // // Returns the number of open objects in file with id fid
+    // int what_is_open(hid_t fid);
 
     // Closes the objects currently open in file with id fid
     int close_all_objects(hid_t fid);

--- a/src/larcv3/core/dataformat/ImageMeta.h
+++ b/src/larcv3/core/dataformat/ImageMeta.h
@@ -172,21 +172,28 @@ class ImageMeta {
 
 #ifndef SWIG
   public: 
-    static H5::CompType get_datatype() {
-      H5::CompType datatype(sizeof(ImageMeta));
+    static hid_t get_datatype() {
+      hid_t datatype;
+      herr_t status;
+      datatype = H5Tcreate (H5T_COMPOUND, sizeof (ImageMeta));
 
       hsize_t array_dimensions[1];
       array_dimensions[0] = dimension;
 
-      H5::ArrayType double_type(larcv3::get_datatype<double>(), 1, array_dimensions);
-      H5::ArrayType size_t_type(larcv3::get_datatype<size_t>(), 1, array_dimensions);
 
-      datatype.insertMember(H5std_string("valid"),            offsetof(ImageMeta, _valid),            larcv3::get_datatype<bool>());
-      datatype.insertMember(H5std_string("projection_id"),    offsetof(ImageMeta, _projection_id),    larcv3::get_datatype<size_t>());
-      datatype.insertMember(H5std_string("image_sizes"),      offsetof(ImageMeta, _image_sizes),      double_type);
-      datatype.insertMember(H5std_string("number_of_voxels"), offsetof(ImageMeta, _number_of_voxels), size_t_type);
-      datatype.insertMember(H5std_string("origin"),           offsetof(ImageMeta, _origin),           double_type);
+      hid_t double_type = H5Tarray_create(larcv3::get_datatype<double>(), 1, array_dimensions);
+      hid_t size_t_type = H5Tarray_create(larcv3::get_datatype<size_t>(), 1, array_dimensions);
 
+      status = H5Tinsert (datatype, "valid",
+                  HOFFSET (ImageMeta, _valid),            larcv3::get_datatype<bool>());
+      status = H5Tinsert (datatype, "projection_id",
+                  HOFFSET (ImageMeta, _projection_id),    larcv3::get_datatype<size_t>());
+      status = H5Tinsert (datatype, "image_sizes",
+                  HOFFSET (ImageMeta, _image_sizes),      double_type);
+      status = H5Tinsert (datatype, "number_of_voxels",
+                  HOFFSET (ImageMeta, _number_of_voxels), size_t_type);
+      status = H5Tinsert (datatype, "origin", 
+                  HOFFSET (ImageMeta, _origin),           double_type);
       return datatype;
     }
 #endif

--- a/src/larcv3/core/dataformat/Particle.h
+++ b/src/larcv3/core/dataformat/Particle.h
@@ -165,37 +165,40 @@ namespace larcv3 {
 
 #ifndef SWIG
   public: 
-    static H5::CompType get_datatype() {
-      H5::CompType datatype(sizeof(Particle));
-
+    static hid_t get_datatype() {
+      hid_t datatype;
+      herr_t status;
+      datatype = H5Tcreate (H5T_COMPOUND, sizeof (Particle));
+      
       // Get the compound types:
-      H5::StrType string_type(0, PARTICLE_PROCESS_STRLEN);
+      hid_t string_type = H5Tcopy (H5T_C_S1);
+      H5Tset_size(string_type, PARTICLE_PROCESS_STRLEN);
 
-      datatype.insertMember(H5std_string("id"),               offsetof(Particle, _id),               larcv3::get_datatype<InstanceID_t>());
-      datatype.insertMember(H5std_string("mcst_index"),       offsetof(Particle, _mcst_index),       larcv3::get_datatype<MCSTIndex_t>());
-      datatype.insertMember(H5std_string("mct_index"),        offsetof(Particle, _mct_index),        larcv3::get_datatype<MCTIndex_t>());
-      datatype.insertMember(H5std_string("shape"),            offsetof(Particle, _shape),            larcv3::get_datatype<ShapeType_t>());
-      datatype.insertMember(H5std_string("current_type"),     offsetof(Particle, _current_type),     larcv3::get_datatype<short>());
-      datatype.insertMember(H5std_string("interaction_type"), offsetof(Particle, _interaction_type), larcv3::get_datatype<short>());
-      datatype.insertMember(H5std_string("trackid"),          offsetof(Particle, _trackid),          larcv3::get_datatype<unsigned int>());
-      datatype.insertMember(H5std_string("pdg"),              offsetof(Particle, _pdg),              larcv3::get_datatype<int>());
-      datatype.insertMember(H5std_string("px"),               offsetof(Particle, _px),               larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("py"),               offsetof(Particle, _py),               larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("pz"),               offsetof(Particle, _pz),               larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("vtx"),              offsetof(Particle, _vtx),              Vertex::get_datatype());
-      datatype.insertMember(H5std_string("end_pt"),           offsetof(Particle, _end_pt),           Vertex::get_datatype());
-      datatype.insertMember(H5std_string("first_step"),       offsetof(Particle, _first_step),       Vertex::get_datatype());
-      datatype.insertMember(H5std_string("last_step"),        offsetof(Particle, _last_step),        Vertex::get_datatype());
-      datatype.insertMember(H5std_string("dist_travel"),      offsetof(Particle, _dist_travel),      larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("energy_init"),      offsetof(Particle, _energy_init),      larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("energy_deposit"),   offsetof(Particle, _energy_deposit),   larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("process"),          offsetof(Particle, _process),          string_type);
-      datatype.insertMember(H5std_string("parent_trackid"),   offsetof(Particle, _parent_trackid),   larcv3::get_datatype<unsigned int>());
-      datatype.insertMember(H5std_string("parent_pdg"),       offsetof(Particle, _parent_pdg),       larcv3::get_datatype<int>());
-      datatype.insertMember(H5std_string("parent_vtx"),       offsetof(Particle, _parent_vtx),       Vertex::get_datatype());
-      datatype.insertMember(H5std_string("ancestor_trackid"), offsetof(Particle, _ancestor_trackid), larcv3::get_datatype<unsigned int>());
-      datatype.insertMember(H5std_string("ancestor_pdg"),     offsetof(Particle, _ancestor_pdg),     larcv3::get_datatype<int>());
-      datatype.insertMember(H5std_string("ancestor_vtx"),     offsetof(Particle, _ancestor_vtx),     Vertex::get_datatype());
+      status = H5Tinsert(datatype, "id",               HOFFSET(Particle, _id),               larcv3::get_datatype<InstanceID_t>());
+      status = H5Tinsert(datatype, "mcst_index",       HOFFSET(Particle, _mcst_index),       larcv3::get_datatype<MCSTIndex_t>());
+      status = H5Tinsert(datatype, "mct_index",        HOFFSET(Particle, _mct_index),        larcv3::get_datatype<MCTIndex_t>());
+      status = H5Tinsert(datatype, "shape",            HOFFSET(Particle, _shape),            larcv3::get_datatype<ShapeType_t>());
+      status = H5Tinsert(datatype, "current_type",     HOFFSET(Particle, _current_type),     larcv3::get_datatype<short>());
+      status = H5Tinsert(datatype, "interaction_type", HOFFSET(Particle, _interaction_type), larcv3::get_datatype<short>());
+      status = H5Tinsert(datatype, "trackid",          HOFFSET(Particle, _trackid),          larcv3::get_datatype<unsigned int>());
+      status = H5Tinsert(datatype, "pdg",              HOFFSET(Particle, _pdg),              larcv3::get_datatype<int>());
+      status = H5Tinsert(datatype, "px",               HOFFSET(Particle, _px),               larcv3::get_datatype<double>());
+      status = H5Tinsert(datatype, "py",               HOFFSET(Particle, _py),               larcv3::get_datatype<double>());
+      status = H5Tinsert(datatype, "pz",               HOFFSET(Particle, _pz),               larcv3::get_datatype<double>());
+      status = H5Tinsert(datatype, "vtx",              HOFFSET(Particle, _vtx),              Vertex::get_datatype());
+      status = H5Tinsert(datatype, "end_pt",           HOFFSET(Particle, _end_pt),           Vertex::get_datatype());
+      status = H5Tinsert(datatype, "first_step",       HOFFSET(Particle, _first_step),       Vertex::get_datatype());
+      status = H5Tinsert(datatype, "last_step",        HOFFSET(Particle, _last_step),        Vertex::get_datatype());
+      status = H5Tinsert(datatype, "dist_travel",      HOFFSET(Particle, _dist_travel),      larcv3::get_datatype<double>());
+      status = H5Tinsert(datatype, "energy_init",      HOFFSET(Particle, _energy_init),      larcv3::get_datatype<double>());
+      status = H5Tinsert(datatype, "energy_deposit",   HOFFSET(Particle, _energy_deposit),   larcv3::get_datatype<double>());
+      status = H5Tinsert(datatype, "process",          HOFFSET(Particle, _process),          string_type);
+      status = H5Tinsert(datatype, "parent_trackid",   HOFFSET(Particle, _parent_trackid),   larcv3::get_datatype<unsigned int>());
+      status = H5Tinsert(datatype, "parent_pdg",       HOFFSET(Particle, _parent_pdg),       larcv3::get_datatype<int>());
+      status = H5Tinsert(datatype, "parent_vtx",       HOFFSET(Particle, _parent_vtx),       Vertex::get_datatype());
+      status = H5Tinsert(datatype, "ancestor_trackid", HOFFSET(Particle, _ancestor_trackid), larcv3::get_datatype<unsigned int>());
+      status = H5Tinsert(datatype, "ancestor_pdg",     HOFFSET(Particle, _ancestor_pdg),     larcv3::get_datatype<int>());
+      status = H5Tinsert(datatype, "ancestor_vtx",     HOFFSET(Particle, _ancestor_vtx),     Vertex::get_datatype());
 
       return datatype;
     }

--- a/src/larcv3/core/dataformat/Vertex.h
+++ b/src/larcv3/core/dataformat/Vertex.h
@@ -67,12 +67,18 @@ namespace larcv3 {
 
 #ifndef SWIG
   public: 
-    static H5::CompType get_datatype() {
-      H5::CompType datatype(sizeof(Vertex));
-      datatype.insertMember(H5std_string("x"), offsetof(Vertex, _x), larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("y"), offsetof(Vertex, _y), larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("z"), offsetof(Vertex, _z), larcv3::get_datatype<double>());
-      datatype.insertMember(H5std_string("t"), offsetof(Vertex, _t), larcv3::get_datatype<double>());
+    static hid_t get_datatype() {
+      hid_t datatype;
+      herr_t status;
+      datatype = H5Tcreate (H5T_COMPOUND, sizeof (Vertex));
+      status = H5Tinsert (datatype, "x",
+                  HOFFSET (Vertex, _x), larcv3::get_datatype<double>());
+      status = H5Tinsert (datatype, "y",
+                  HOFFSET (Vertex, _y), larcv3::get_datatype<double>());
+      status = H5Tinsert (datatype, "z",
+                  HOFFSET (Vertex, _z), larcv3::get_datatype<double>());
+      status = H5Tinsert (datatype, "t", 
+                  HOFFSET (Vertex, _t), larcv3::get_datatype<double>());
       return datatype;
     }
 #endif

--- a/src/larcv3/core/dataformat/Voxel.h
+++ b/src/larcv3/core/dataformat/Voxel.h
@@ -87,10 +87,15 @@ namespace larcv3 {
 
 #ifndef SWIG
   public: 
-    static H5::CompType get_datatype() {
-      H5::CompType datatype(sizeof(Voxel));
-      datatype.insertMember(H5std_string("id"), offsetof(Voxel, _id), H5::PredType::NATIVE_ULLONG);
-      datatype.insertMember(H5std_string("value"), offsetof(Voxel, _value), H5::PredType::NATIVE_FLOAT);
+    static hid_t get_datatype() {
+
+      hid_t datatype;
+      herr_t status;
+      datatype = H5Tcreate (H5T_COMPOUND, sizeof (Voxel));
+      status = H5Tinsert (datatype, "id",
+                  HOFFSET (Voxel, _id), larcv3::get_datatype<unsigned long>());
+      status = H5Tinsert (datatype, "value", 
+                  HOFFSET (Voxel, _value), larcv3::get_datatype<float>());
       return datatype;
     }
 #endif

--- a/tests/larcv/app/threadio/test_queueio_SparseTensor3D.py
+++ b/tests/larcv/app/threadio/test_queueio_SparseTensor3D.py
@@ -111,16 +111,12 @@ def test_sparsetensor3d_queueio_distributed(tmpdir, make_copy, local_batch_size,
         # Next, write some sparsetensor3ds to that file:
         create_sparsetensor3d_file(file_name, rand_num_events=25)
 
-
-
         # Generate a config for this 
         config_contents = queue_io_sparsetensor3d_cfg_template.format(
             name        = queueio_name,
             input_files = file_name,
-            producer    = "test",
+            producer    = "test", #"sbndvoxels",
             )
-
-
 
         with open(str(config_file), 'w') as _f:
             _f.write(config_contents)
@@ -144,12 +140,10 @@ def test_sparsetensor3d_queueio_distributed(tmpdir, make_copy, local_batch_size,
         'label': 'test_{}'.format(queueio_name), 
         })
 
-
-
     li = distributed_queue_interface.queue_interface()
+
     # Scale the number of images to the mpi comm size:
     li.prepare_manager('primary', io_config, comm_size * local_batch_size, data_keys, color=0)
-
 
     for i in range(n_reads):
         data = li.fetch_minibatch_data('primary')


### PR DESCRIPTION
…This should allow larcv3 to get a little closer to proper MPI-IO behavior and optimizations.  This is not verified yet, but the C++ API calls were a problem preventing this.