### PR TITLE
This commit moves all pybind11 into LARCV_INTERNAL protected areas in…

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -18,6 +18,10 @@ if 'LARCV_WITH_OPENMP' in os.environ and os.environ['LARCV_WITH_OPENMP']:
 else:
     openmp_value='OFF'
 
+if 'LARCV_WITHOUT_PYBIND' in os.environ and os.environ['LARCV_WITHOUT_PYBIND']:
+    pybind_value='OFF'
+else:
+    pybind_value='ON'
 
 
 setup(
@@ -28,7 +32,7 @@ setup(
     include_package_data=True,
     cmake_args=[
         '-DCMAKE_OSX_DEPLOYMENT_TARGET:STRING=10.9',
-        '-DCMAKE_PYTHON_BINDINGS=True',
+        '-DCMAKE_PYTHON_BINDINGS={}'.format(pybind_value),
         # '-DMPI_CXX_COMPILER={}'.format(mpicxx),
         # '-DMPI_C_COMPILER={}'.format(mpicc),
         '-DMPI:BOOL={}'.format(mpi_value),

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -6,6 +6,12 @@ set(CMAKE_CXX_STANDARD 11)
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} -Wall -O3 -g")
 
+# We set a larcv compiler definition to build all of the python code
+# This is obviously not set if you are including headers, which protects
+# the need to install pybind11 outside of larcv (since it's header only,
+# there is no need to link to it.)
+add_definitions(-DLARCV_INTERNAL)
+
 
 if(MPI)
     message (STATUS "MPI_CXX_COMPILER ${MPI_CXX_COMPILER}")
@@ -43,10 +49,6 @@ include_directories("./")
 find_package(HDF5 REQUIRED)
 include_directories(${HDF5_INCLUDE_DIR})
 
-# Many packages need python:
-find_package(PythonLibs REQUIRED)
-include_directories(${PYTHON_INCLUDE_DIRS})
-
 if(OPENMP)
   find_package(OpenMP)
   if(OpenMP_CXX_FOUND)
@@ -55,6 +57,10 @@ if(OPENMP)
 endif()
 
 # This package needs numpy::
+
+# Many packages need python:
+find_package(PythonLibs REQUIRED)
+include_directories(${PYTHON_INCLUDE_DIRS})
 
 ######################################
 # This is from https://github.com/Eyescale/CMake/blob/master/FindNumPy.cmake

--- a/src/larcv3/app/queueio/BatchData.h
+++ b/src/larcv3/app/queueio/BatchData.h
@@ -19,7 +19,10 @@
 #include "QueueIOTypes.h"
 #include "larcv3/core/pyutil/PyUtils.h"
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#endif
 
 namespace larcv3 {
   /**
@@ -46,7 +49,9 @@ namespace larcv3 {
     // Writeable access to data:
     std::vector<T> & writeable_data() {return _data;}
 
+#ifdef LARCV_INTERNAL
     pybind11::array_t<T> pydata();
+#endif
 
     inline const std::vector<int>& dim() const { return _dim; }
     inline const std::vector<int>& dense_dim() const { return _dense_dim; }
@@ -85,11 +90,13 @@ namespace larcv3 {
   };
 }
 
+
+#ifdef LARCV_INTERNAL
 template <class T>
 void init_batchdata_(pybind11::module m);
 
 void init_batchdata(pybind11::module m);
+#endif
 
 #endif
 /** @} */ // end of doxygen group
-

--- a/src/larcv3/app/queueio/BatchDataQueue.h
+++ b/src/larcv3/app/queueio/BatchDataQueue.h
@@ -2,7 +2,7 @@
  * \file BatchDataQueue.h
  *
  * \ingroup ThreadIO
- * 
+ *
  * \brief Class def header for a class BatchDataQueue
  *
  * @author kazuhiro
@@ -25,7 +25,7 @@ namespace larcv3 {
   */
   template <class T>
   class BatchDataQueue {
-    
+
   public:
     /// Default constructor
     BatchDataQueue();
@@ -63,13 +63,17 @@ namespace larcv3 {
     larcv3::BatchData<T> _data_next;
 
   };
-  
+
 }
+
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 template<class T>
 void init_batchdataqueue(pybind11::module m);
 
 void init_batchdataqueue(pybind11::module m);
+#endif
+
 
 #endif
-/** @} */ // end of doxygen group 
-
+/** @} */ // end of doxygen group

--- a/src/larcv3/app/queueio/BatchDataQueueFactory.h
+++ b/src/larcv3/app/queueio/BatchDataQueueFactory.h
@@ -45,7 +45,7 @@ namespace larcv3 {
       auto iter = _queue_m.find(name);
       return iter != _queue_m.end();
     }
-    
+
     bool is_next_ready() const;
 
     // Pop all queues to promote next to current
@@ -75,12 +75,13 @@ namespace larcv3 {
 
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 template<class T>
 void init_batchdataqueuefactory(pybind11::module m);
 
 void init_batchdataqueuefactory(pybind11::module m);
-
+#endif
 
 #endif
 /** @} */ // end of doxygen group
-

--- a/src/larcv3/app/queueio/QueueProcessor.h
+++ b/src/larcv3/app/queueio/QueueProcessor.h
@@ -47,7 +47,7 @@ namespace larcv3 {
     // configure the processor from a file on disk
     void configure(const std::string config_file, int color=0);
 
-    // configure the processor from a PSet object    
+    // configure the processor from a PSet object
     void configure(const PSet& cfg, int color=0);
 
     // Check if the processor is configured
@@ -108,7 +108,7 @@ namespace larcv3 {
     // Each QueueProcessor gets one process driver object.
     // We assume that the batch_process call can be parallelized with OpenMP
     larcv3::ProcessDriver _driver;
-    
+
     // List of processes for fillers:
     std::vector<std::string> _process_name_v;
 
@@ -123,9 +123,10 @@ namespace larcv3 {
   };
 
 }
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_queueprocessor(pybind11::module m);
+#endif
 
 #endif
 /** @} */ // end of doxygen group
-

--- a/src/larcv3/app/queueio/QueueProcessor.h
+++ b/src/larcv3/app/queueio/QueueProcessor.h
@@ -19,6 +19,12 @@
 #include <random>
 #include <future>
 
+
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
+#endif
+
 namespace larcv3 {
   /**
      \class QueueProcessor
@@ -62,6 +68,15 @@ namespace larcv3 {
 
     // Set the next set of indexes to read:
     void set_next_batch(const std::vector<size_t>& index_v);
+
+
+    // These functions only appear in larcv proper, not in included headers:
+#ifdef LARCV_INTERNAL
+    /// from numpy ctor
+    void set_next_batch(pybind11::array_t <size_t> index_v);
+
+#endif
+
 
     // Return true only if the fillers are preparing the next batch
     bool is_reading() const {return _processing;}

--- a/src/larcv3/app/queueio/queueio.h
+++ b/src/larcv3/app/queueio/queueio.h
@@ -3,7 +3,7 @@
  * \file larbys.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief Class def header for exception classes for larcv3 framework
  *
  * @author cadams
@@ -23,9 +23,10 @@
 #include "QueueProcessor.h"
 
 #ifndef LARCV_NO_PYBIND
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 __attribute__ ((visibility ("default"))) void init_queueio(pybind11::module m);
-
+#endif
 // bindings
 #endif
 

--- a/src/larcv3/core/base/LArCVTypes.h
+++ b/src/larcv3/core/base/LArCVTypes.h
@@ -2,7 +2,7 @@
  * \file LArCVTypes.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief basic typedefs and enums (larcv3::Point2D, larcv3::msg, etc.)
  *
  * @author Kazu - Nevis 2015
@@ -26,7 +26,6 @@
 #include <limits>
 #include <climits>
 
-#include <pybind11/pybind11.h>
 
 /**
    \namespace larcv3
@@ -48,7 +47,7 @@ namespace larcv3 {
   const short              kINVALID_SHORT     = std::numeric_limits< short              >::max();
   /// Used as an invalid value identifier for unsigned unsigned short
   const unsigned short     kINVALID_USHORT    = std::numeric_limits< unsigned short     >::max();
-  /// Used as an invalid value identifier for single-point precision  
+  /// Used as an invalid value identifier for single-point precision
   const float              kINVALID_FLOAT     = std::numeric_limits< float              >::max();
   /// Used as an invalid value identifier for double-point precision
   const double             kINVALID_DOUBLE    = std::numeric_limits< double             >::max();

--- a/src/larcv3/core/base/PSet.h
+++ b/src/larcv3/core/base/PSet.h
@@ -2,7 +2,7 @@
  * \file PSet.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief Class def header for a class larcv3::PSet
  *
  * @author kazuhiro
@@ -27,9 +27,9 @@ namespace larcv3 {
      \brief A nested configuration parameter set holder for larcv3 framework.
   */
   class PSet {
-    
+
   public:
-    
+
     /// Default constructor
     PSet(const std::string name="",
          const std::string data="");
@@ -45,7 +45,7 @@ namespace larcv3 {
 
     /// name getter
     inline const std::string& name() const { return _name; }
-    
+
     /// operator override
     inline bool operator==(const PSet& rhs) const
     {
@@ -76,7 +76,7 @@ namespace larcv3 {
     inline void rename(std::string name) { _name = name; }
 
     /// clear method
-    inline void clear() 
+    inline void clear()
     { _data_value.clear(); _data_pset.clear(); }
 
     /// Set data contents
@@ -93,7 +93,7 @@ namespace larcv3 {
                   std::string pset);
 
     void update(std::string key, std::string value);
-    
+
     std::string & operator[] (std::string key);
 
     /// Dump into a text format
@@ -169,13 +169,13 @@ namespace larcv3 {
   };
 
   template<> PSet PSet::get<larcv3::PSet>(const std::string& key) const;
-  
+
 }
 
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_PSet(pybind11::module m);
-
+#endif
 
 #endif
-/** @} */ // end of doxygen group 
-
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/base/Parser.h
+++ b/src/larcv3/core/base/Parser.h
@@ -2,7 +2,7 @@
  * \file Parser.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief List of functions to type-cast std::string to an appropriate value type
  *
  * @author Kazu - Nevis 2015
@@ -18,7 +18,6 @@
 #include <vector>
 #include <algorithm>
 
-#include <pybind11/pybind11.h>
 
 namespace larcv3 {
   namespace parser {
@@ -73,8 +72,7 @@ namespace larcv3 {
     template <class T> std::string VecToString(const std::vector<T>& value)
     {
       std::string res="[";
-      for(auto const& v : value)
-	res += ToString(v) + ",";
+      for(auto const& v : value) res += ToString(v) + ",";
       res = res.substr(0,res.size()-1);
       res += "]";
       return res;

--- a/src/larcv3/core/base/Watch.h
+++ b/src/larcv3/core/base/Watch.h
@@ -4,7 +4,7 @@
  * \file Watch.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief Class def header for a class larcv3::Watch
  *
  * @author kazuhiro
@@ -17,7 +17,6 @@
 #include <sys/time.h>
 #include <time.h>
 
-#include <pybind11/pybind11.h>
 
 namespace larcv3 {
 
@@ -61,7 +60,11 @@ namespace larcv3 {
   };
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_Watch(pybind11::module m);
+#endif
+
 
 #endif
-/** @} */ // end of doxygen group 
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/base/base.h
+++ b/src/larcv3/core/base/base.h
@@ -2,7 +2,7 @@
  * \file larbys.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief Class def header for exception classes for larcv3 framework
  *
  * @author cadams
@@ -21,9 +21,10 @@
 #include "Watch.h"
 
 #ifndef LARCV_NO_PYBIND
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 __attribute__ ((visibility ("default"))) void init_base(pybind11::module m);
-
+#endif
 // bindings
 #endif
 

--- a/src/larcv3/core/base/larbys.h
+++ b/src/larcv3/core/base/larbys.h
@@ -2,7 +2,7 @@
  * \file larbys.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief Class def header for exception classes for larcv3 framework
  *
  * @author kazuhiro tmw
@@ -17,7 +17,6 @@
 #include <iostream>
 #include <exception>
 
-#include <pybind11/pybind11.h>
 
 
 
@@ -25,12 +24,12 @@ namespace larcv3 {
 
   /**
      \class larbys
-     Throw insignificant larbys when you find nonesense 
+     Throw insignificant larbys when you find nonesense
   */
   class larbys : public std::exception {
-    
+
   public:
-    
+
     larbys(std::string msg="") : std::exception()
     {
       _msg = "\033[93m";
@@ -43,18 +42,19 @@ namespace larcv3 {
     { return _msg.c_str(); }
 
   private:
-    
+
     std::string _msg;
   };
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_larbys(pybind11::module m);
-
+#endif
 
 // PYBIND11_MODULE(larcv, m) {
 //   init_larbys(m);
 // }
 
 #endif
-/** @} */ // end of doxygen group 
-
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/base/larcv_base.h
+++ b/src/larcv3/core/base/larcv_base.h
@@ -2,7 +2,7 @@
  * \file larcv_base.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief Class definition file of larcv3::larcv_base
  *
  * @author Kazu - Nevis 2015
@@ -19,30 +19,30 @@
 #include "larcv3/core/base/larcv_logger.h"
 
 namespace larcv3 {
-    
+
   /**
     \class larcv_base
     Framework base class equipped with a logger class
   */
   class larcv_base {
-    
+
   public:
-    
+
     /// Default constructor
     larcv_base(const std::string logger_name="larcv_base")
       : _logger(nullptr)
     { _logger = &(::larcv3::logger::get(logger_name)); }
-    
+
     /// Default copy constructor
     larcv_base(const larcv_base &original) : _logger(original._logger) {}
-    
+
     /// Default destructor
     virtual ~larcv_base(){};
-    
+
     /// Logger getter
     inline const larcv3::logger& logger() const
     { return *_logger; }
-    
+
     /// Verbosity level
     void set_verbosity(::larcv3::msg::Level_t level)
     { _logger->set(level); }
@@ -50,15 +50,18 @@ namespace larcv3 {
     /// Name getter, defined in a logger instance attribute
     const std::string& name() const
     { return logger().name(); }
-    
+
   private:
-    
+
     larcv3::logger *_logger;   ///< logger
-    
+
   };
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_larcv_base(pybind11::module m);
+#endif
 
 #endif
 

--- a/src/larcv3/core/base/larcv_logger.h
+++ b/src/larcv3/core/base/larcv_logger.h
@@ -2,7 +2,7 @@
  * \file larcv_logger.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief larcv3::logger utility class definition header file.
  *
  * @author Kazu - Nevis 2015
@@ -30,29 +30,29 @@ namespace larcv3 {
      A static getter method is provided to create a sharable logger instance (see larcv_base for useage). \n
   */
   class logger{
-    
+
   public:
-    
+
     /// Default constructor
     logger(const std::string& name="no_name")
       : _ostrm(&std::cout)
       , _name(name)
     {}
-    
+
     /// Default destructor
     virtual ~logger(){};
-    
+
   private:
-    
+
     /// ostream
     std::ostream *_ostrm;
-    
+
     /// Level
     msg::Level_t _level;
-      
+
     /// Name
     std::string _name;
-    
+
     /// Set of loggers
     static std::map<std::string,larcv3::logger> *_logger_m;
 
@@ -61,7 +61,7 @@ namespace larcv3 {
 
     /// Default logger level
     static msg::Level_t _level_default;
-    
+
   public:
 
     /// Logger's name
@@ -80,8 +80,8 @@ namespace larcv3 {
       if(_name > rhs.name()) return false;
       return false;
     }
-    
-    /// Getter of a message instance 
+
+    /// Getter of a message instance
     static logger& get(const std::string name)
     {
       if(!_logger_m) _logger_m = new std::map<std::string,larcv3::logger>();
@@ -128,13 +128,15 @@ namespace larcv3 {
                        const std::string& function,
                        const unsigned int line_num,
                        const std::string& file_name) const;
-    
+
   };
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 // Wrapper init function:
 void init_logger(pybind11::module m);
-
+#endif
 
 
 //
@@ -159,6 +161,6 @@ void init_logger(pybind11::module m);
 #define LARCV_SWARNING()  if(larcv3::logger::get_shared().warning())  larcv3::logger::get_shared().send(::larcv3::msg::kWARNING,  __FUNCTION__                  )
 #define LARCV_SERROR()    if(larcv3::logger::get_shared().error())    larcv3::logger::get_shared().send(::larcv3::msg::kERROR,    __FUNCTION__,__LINE__         )
 #define LARCV_SCRITICAL() larcv3::logger::get_shared().send(::larcv3::msg::kCRITICAL, __FUNCTION__,__LINE__,__FILE__)
-  
+
 /** @} */ // end of doxygen group logger
 #endif

--- a/src/larcv3/core/dataformat/BBox.h
+++ b/src/larcv3/core/dataformat/BBox.h
@@ -30,10 +30,10 @@ namespace larcv3 {
 
     BBox() {}
 
-    BBox(Point<dimension> min, Point<dimension> max, ProjectionID_t id = kINVALID_PROJECTIONID);    
-    
+    BBox(Point<dimension> min, Point<dimension> max, ProjectionID_t id = kINVALID_PROJECTIONID);
+
     inline bool operator== (const BBox<dimension>& rhs) const {
-      return (_p1 == rhs._p1 && _p2 == rhs._p2); 
+      return (_p1 == rhs._p1 && _p2 == rhs._p2);
     }
 
     void update(const std::vector<double> & min, const std::vector<double> & max,
@@ -53,15 +53,15 @@ namespace larcv3 {
     inline Point<dimension> max        () const { return _p1;}
     inline Point<dimension> dimensions () const { return _p2 - _p1; }
     inline double           area       () const { return volume(); }
-    inline double           volume     () const { 
+    inline double           volume     () const {
       double v = 1.0;
       Point<dimension> res = _p2 - _p1;
       for (size_t i = 0; i < dimension; i ++){
         v *= res.x[i];
       }
-      return v; 
+      return v;
     }
-    
+
     inline ProjectionID_t id() const { return _id; }
     std::string dump() const;
 
@@ -79,10 +79,14 @@ namespace larcv3 {
   typedef BBox<3> BBox3D;
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 template<size_t dimension>
 void init_bbox_base(pybind11::module m);
 
 void init_bbox(pybind11::module m);
+#endif
+
 
 #endif
 /** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/DataFormatTypes.cxx
+++ b/src/larcv3/core/dataformat/DataFormatTypes.cxx
@@ -71,7 +71,7 @@ namespace larcv3{
                HOFFSET (Extents_t, first),
                larcv3::get_datatype<unsigned long long int>());
     H5Tinsert (datatype, "N",
-               HOFFSET (Extents_t, n),     
+               HOFFSET (Extents_t, n),
                larcv3::get_datatype<unsigned int>());
     return datatype;
 
@@ -126,7 +126,7 @@ void init_dataformattypes(pybind11::module m){
   m.attr("kINVALID_PROJECTIONID") = larcv3::kINVALID_PROJECTIONID;
   m.attr("kINVALID_VOXELID")      = larcv3::kINVALID_VOXELID;
   m.attr("kINVALID_PRODUCER")     = larcv3::kINVALID_PRODUCER;
-  
+
   pybind11::enum_<larcv3::PoolType_t> pooltype_t(m,"PoolType_t");
   pooltype_t.value("kPoolSum",      larcv3::PoolType_t::kPoolSum);
   pooltype_t.value("kPoolAverage",  larcv3::PoolType_t::kPoolAverage);

--- a/src/larcv3/core/dataformat/DataFormatTypes.h
+++ b/src/larcv3/core/dataformat/DataFormatTypes.h
@@ -2,15 +2,15 @@
 #define __LARCV3DATAFORMAT_DATAFORMATTYPES_H__
 
 #include "larcv3/core/base/LArCVTypes.h"
-#include "hdf5.h"
 #include <vector>
 #include <set>
+#include "hdf5.h"
 
 namespace larcv3 {
 
   /// Invalid rep for vector index
   static const unsigned short kINVALID_INDEX = kINVALID_USHORT;
-  /// Image index type for Image2D within EventImage2D  
+  /// Image index type for Image2D within EventImage2D
   typedef unsigned short ImageIndex_t;
   /// ROI index type for Particle within EventROI
   typedef unsigned short ParticleIndex_t;
@@ -49,7 +49,7 @@ namespace larcv3 {
     static const short kNOTPRESENT = -1;        ///< Channel does not exist
     static const short kNEGATIVEPEDESTAL = -2;  ///< Channel not reco-ed due to pedestal < 0
     /// Standard channel status enum stored in the database
-    enum ChannelStatus_t : int { 
+    enum ChannelStatus_t : int {
       kDISCONNECTED=0, ///< Channel is not connected
       kDEAD=1,         ///< Dead channel
       kLOWNOISE=2,     ///< Abnormally low noise channel
@@ -73,7 +73,7 @@ namespace larcv3 {
     kPoolMax      ///< max channel
   };
 
-  /// Object appearance type in LArTPC  
+  /// Object appearance type in LArTPC
   enum ShapeType_t : int {
     kShapeShower,  ///< Shower
     kShapeTrack,   ///< Track
@@ -106,8 +106,6 @@ namespace larcv3 {
   // In this section, we define and specialize a number of cases for mapping
   // datatypes used in larcv3 to datatypes needed for hdf5 serialization.
 
-  void init_dataformattypes(pybind11::module m);
-
   template <typename T>
   hid_t get_datatype();
 
@@ -117,6 +115,9 @@ namespace larcv3 {
 
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_dataformattypes(pybind11::module m);
+#endif
 
 #endif

--- a/src/larcv3/core/dataformat/DataProductFactory.h
+++ b/src/larcv3/core/dataformat/DataProductFactory.h
@@ -2,7 +2,7 @@
  * \file DataProductFactory.h
  *
  * \ingroup DataFormat
- * 
+ *
  * \brief Class def header for a class DataProductFactory
  *
  * @author kazuhiro
@@ -21,6 +21,7 @@
 #include "larcv3/core/dataformat/EventBase.h"
 #include "larcv3/core/dataformat/DataFormatTypes.h"
 #include <sstream>
+
 namespace larcv3 {
 
   class EventBase;
@@ -57,7 +58,7 @@ namespace larcv3 {
     /// Static sharable instance getter
     static inline DataProductFactory& get()
     { if(!_me) _me = new DataProductFactory; return *_me; }
-    
+
     /// Factory registration method (should be called by global factory instance in algorithm header)
     void add_factory(std::string type, larcv3::DataProductFactoryBase* factory);
 
@@ -65,7 +66,7 @@ namespace larcv3 {
     inline EventBase* create(const std::string& type, const std::string& producer) {
       return create(ProducerName_t(type,producer));
     }
-    
+
     /// Factory creation method (should be called by clients, possibly you!)
     EventBase* create(const ProducerName_t& id);
 
@@ -88,5 +89,4 @@ namespace larcv3 {
   };
 }
 #endif
-/** @} */ // end of doxygen group 
-
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/EventBase.h
+++ b/src/larcv3/core/dataformat/EventBase.h
@@ -2,7 +2,7 @@
  * \file EventBase.h
  *
  * \ingroup DataFormat
- * 
+ *
  * \brief Class def header for a class EventBase
  *
  * @author cadams, kazuhiro
@@ -31,7 +31,7 @@ namespace larcv3 {
     friend class IOManager;
     friend class DataProductFactory;
   public:
-    
+
     virtual ~EventBase() = 0;
 
     virtual void clear() = 0;
@@ -58,8 +58,10 @@ namespace larcv3 {
 
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_eventbase(pybind11::module m);
+#endif
 
 #endif //inc guard
-/** @} */ // end of doxygen group 
-
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/EventID.h
+++ b/src/larcv3/core/dataformat/EventID.h
@@ -15,7 +15,6 @@
 #define __LARCV3DATAFORMAT_EVENTID_H
 
 #include <iostream>
-#include "hdf5.h"
 #include "larcv3/core/dataformat/DataFormatTypes.h"
 
 namespace larcv3 {
@@ -107,7 +106,10 @@ class EventID {
 };
 }  // namespace larcv3
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_eventid(pybind11::module m);
+#endif
 
 #endif
 /** @} */  // end of doxygen group

--- a/src/larcv3/core/dataformat/EventParticle.h
+++ b/src/larcv3/core/dataformat/EventParticle.h
@@ -2,7 +2,7 @@
  * \file EventParticle.h
  *
  * \ingroup DataFormat
- * 
+ *
  * \brief Class def header for a class EventParticle
  *
  * @author kazuhiro
@@ -26,18 +26,18 @@ namespace larcv3 {
     User-defined data product class (please comment!)
   */
   class EventParticle : public EventBase {
-    
+
   public:
-    
+
     /// Default constructor
     EventParticle();
-    
+
     /// Default destructor
     ~EventParticle(){}
 
     inline larcv3::Particle at(size_t index) {return _part_v.at(index);}
 
-    
+
 
     void set(const std::vector<larcv3::Particle>& part_v);
     void append(const larcv3::Particle& part);
@@ -65,7 +65,7 @@ namespace larcv3 {
   private:
 
     void open_in_datasets(hid_t group);
-    void open_out_datasets(hid_t group);    
+    void open_out_datasets(hid_t group);
 
     std::vector<larcv3::Particle> _part_v; ///< a collection of particles (index maintained)
 
@@ -77,11 +77,11 @@ namespace larcv3 {
 namespace larcv3 {
 
   // Template instantiation for IO
-  template<> 
+  template<>
   inline std::string product_unique_name<larcv3::EventParticle>() { return "particle"; }
-  // template<> 
+  // template<>
   // inline EventParticle& IOManager::get_data(const std::string&);
-  // template<> 
+  // template<>
   // inline EventParticle& IOManager::get_data(const ProducerID_t);
 
   /**
@@ -99,11 +99,13 @@ namespace larcv3 {
     EventBase* create() { return new EventParticle; }
   };
 
-  
+
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_eventparticle(pybind11::module m);
+#endif
 
 #endif
-/** @} */ // end of doxygen group 
-
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/EventSparseCluster.h
+++ b/src/larcv3/core/dataformat/EventSparseCluster.h
@@ -7,7 +7,7 @@
  *
  * @author kazuhiro
  * @author cadams
- 
+
 
  * \addtogroup core_DataFormat
 
@@ -95,10 +95,10 @@ namespace larcv3 {
   template<> inline std::string product_unique_name<larcv3::EventSparseCluster2D>() { return "cluster2d"; }
   template<> inline std::string product_unique_name<larcv3::EventSparseCluster3D>() { return "cluster3d"; }
 
-  
+
   //    \class larcv3::EventSparseCluster
   //    \brief A concrete factory class for larcv3::EventSparseCluster
-  
+
 
   class EventSparseCluster2DFactory : public DataProductFactoryBase {
   public:
@@ -110,7 +110,7 @@ namespace larcv3 {
     /// create method
     EventBase* create() { return new EventSparseCluster2D; }
   };
-  
+
   class EventSparseCluster3DFactory : public DataProductFactoryBase {
   public:
     /// ctor
@@ -124,12 +124,14 @@ namespace larcv3 {
 
 }
 
+
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 template<size_t dimension>
 void init_eventsparse_cluster_base(pybind11::module m);
 
 void init_eventsparsecluster(pybind11::module m);
-
+#endif
 
 #endif
 /** @} */ // end of doxygen group
-

--- a/src/larcv3/core/dataformat/EventSparseTensor.h
+++ b/src/larcv3/core/dataformat/EventSparseTensor.h
@@ -8,7 +8,7 @@
  *
  * @author kazuhiro
  * @author cadams
- 
+
  * \addtogroup core_DataFormat
 */
 
@@ -30,7 +30,7 @@ namespace larcv3 {
     \class EventSparseTensor
     \brief Event-wise class to store a collection of VoxelSet (cluster) per projection id
   */
-  template<size_t dimension> 
+  template<size_t dimension>
   class EventSparseTensor : public EventBase {
 
   public:
@@ -76,7 +76,7 @@ namespace larcv3 {
   private:
     void open_in_datasets(hid_t group);
     void open_out_datasets(hid_t group);
-    
+
     std::vector<larcv3::SparseTensor<dimension> >  _tensor_v;
 
 
@@ -119,11 +119,13 @@ namespace larcv3 {
 
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 template<size_t dimension>
 void init_eventsparse_tensor_base(pybind11::module m);
 
 void init_eventsparsetensor(pybind11::module m);
-
+#endif
 
 #endif
 /** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/EventTensor.h
+++ b/src/larcv3/core/dataformat/EventTensor.h
@@ -2,7 +2,7 @@
  * \file EventTensor.h
  *
  * \ingroup DataFormat
- * 
+ *
  * \brief Class def header for a class EventTensor (was EventImage2D)
  *
  * @author kazuhiro
@@ -20,19 +20,19 @@
 #include "larcv3/core/dataformat/Tensor.h"
 #include "larcv3/core/dataformat/DataProductFactory.h"
 
-#include <pybind11/numpy.h>
+// #include <pybind11/numpy.h>
 
 namespace larcv3 {
-  
+
   /**
     \class EventTensor
     Event-wise class to store a collection of larcv3::Tensor
   */
   template<size_t dimension>
   class EventTensor : public EventBase {
-    
+
   public:
-    
+
     EventTensor();
 
     /// Const reference getter to an array of larcv3::Tensor<dimension>
@@ -43,7 +43,7 @@ namespace larcv3 {
 
     // inline std::shared_ptr<larcv3::Tensor<dimension>>& at(size_t index) const {return _image_v.at(index);}
 
-    /// Deprecated (use as_vector): const reference getter to an array of larcv3::Tensor<dimension> 
+    /// Deprecated (use as_vector): const reference getter to an array of larcv3::Tensor<dimension>
     const std::vector<larcv3::Tensor<dimension>>& image2d_array() const { return _image_v; }
 
     /// Access Tensor<dimension> of a specific projection ID
@@ -64,12 +64,12 @@ namespace larcv3 {
     /// std::move to retrieve content larcv3::Tensor<dimension> array
     void move(std::vector<larcv3::Tensor<dimension>>& image_v)
     { image_v = std::move(_image_v); }
-    
+
     void initialize (hid_t group, uint compression);
     void serialize  (hid_t group);
     void deserialize(hid_t group, size_t entry, bool reopen_groups=false);
     void finalize   ();
-    
+
   private:
     void open_in_datasets(hid_t group);
     void open_out_datasets(hid_t group);
@@ -116,12 +116,13 @@ namespace larcv3 {
 
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 template<size_t dimension>
 void init_event_tensor_base(pybind11::module m);
 
 void init_eventtensor(pybind11::module m);
-
+#endif
 
 #endif
-/** @} */ // end of doxygen group 
-
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/IOManager.h
+++ b/src/larcv3/core/dataformat/IOManager.h
@@ -18,6 +18,7 @@
 #include <iostream>
 #include <map>
 #include <set>
+#include <memory>
 
 #include "hdf5.h"
 

--- a/src/larcv3/core/dataformat/IOManager.h
+++ b/src/larcv3/core/dataformat/IOManager.h
@@ -219,7 +219,7 @@ namespace larcv3 {
 
 
     // Hold a copy of the file access property list:
-    hid_t  _fapl; //FileAccPropList 
+    hid_t  _fapl; //FileAccPropList
 
     std::map<std::string, hid_t> _groups;
 
@@ -259,9 +259,10 @@ namespace larcv3 {
   };
 
 }
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_iomanager(pybind11::module m);
+#endif
 
 #endif
 /** @} */ // end of doxygen group
-    

--- a/src/larcv3/core/dataformat/ImageMeta.h
+++ b/src/larcv3/core/dataformat/ImageMeta.h
@@ -238,11 +238,15 @@ typedef ImageMeta<4> ImageMeta4D;
 
 }  // namespace larcv3
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
+
 void init_imagemeta(pybind11::module m);
 
 template<size_t dimension>
 void init_imagemeta_base(pybind11::module m);
 
+#endif
 
 #endif
 /** @} */  // end of doxygen group

--- a/src/larcv3/core/dataformat/ImageMeta.h
+++ b/src/larcv3/core/dataformat/ImageMeta.h
@@ -23,6 +23,7 @@
 #define __LARCV3DATAFORMAT_IMAGEMETA_H__
 
 #include <iostream>
+#include <array>
 #include "larcv3/core/dataformat/DataFormatTypes.h"
 #include "larcv3/core/base/larbys.h"
 

--- a/src/larcv3/core/dataformat/Particle.h
+++ b/src/larcv3/core/dataformat/Particle.h
@@ -292,8 +292,10 @@ namespace larcv3 {
 
 
 }
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_particle(pybind11::module m);
+#endif
 
 #endif
 /** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/Point.h
+++ b/src/larcv3/core/dataformat/Point.h
@@ -17,7 +17,7 @@
 #include <iostream>
 #include <cmath>
 #include <cassert>
-#include <pybind11/pybind11.h>
+#include <array>
 
 
 namespace larcv3 {
@@ -32,14 +32,14 @@ namespace larcv3 {
         ~Point() {}
 
         Point(const Point<dimension>& pt){
-            
+
             for(size_t i = 0; i < dimension; i ++) x[i] = pt.x[i];
         };
 
         std::array<double, dimension> x;
 
         inline bool operator== (const Point<dimension>& rhs) const {
-            
+
             bool eq = true;
             for(size_t i = 0; i < dimension; i ++) eq = (eq && x[i] == rhs.x[i]);
             return eq;
@@ -60,13 +60,13 @@ namespace larcv3 {
         }
 
         inline Point& operator+= (const Point<dimension>& rhs) {
-            
+
             for(size_t i = 0; i < dimension; i ++) x[i] += rhs.x[i];
             return (*this);
         }
 
         inline Point& operator-= (const Point<dimension>& rhs) {
-            
+
             for(size_t i = 0; i < dimension; i ++) x[i] -= rhs.x[i];
             return (*this);
         }
@@ -83,14 +83,14 @@ namespace larcv3 {
         }
 
         inline Point operator+ (const Point<dimension>& rhs) const {
-            
+
             std::array<double, dimension> new_x;
             for(size_t i = 0; i < dimension; i ++) new_x[i] = x[i] + rhs.x[i];
             return Point(new_x);
         }
 
         inline Point operator- (const Point<dimension>& rhs) const {
-            
+
             std::array<double, dimension> new_x;
             for(size_t i = 0; i < dimension; i ++) new_x[i] = x[i] - rhs.x[i];
             return Point(new_x);
@@ -98,19 +98,19 @@ namespace larcv3 {
 
 
         inline double squared_distance(const Point& pt) const {
-            
+
             double res(0.0);
             for(size_t i = 0; i < dimension; i ++) res += pow(x[i]-pt.x[i],2);
             return res;
         }
 
         inline double distance(const Point& pt) const {
-            
+
             return sqrt(squared_distance(pt));
         }
 
         inline Point direction(const Point& pt) const {
-            
+
             Point res(pt - *this);
             res /= distance(pt); return res;
         }
@@ -121,10 +121,13 @@ typedef Point<2> Point2D;
 typedef Point<3> Point3D;
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 template <size_t dimension>
 void init_point_base(pybind11::module  m);
 
 void init_point(pybind11::module  m);
+#endif
 
 #endif
 /** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/Tensor.h
+++ b/src/larcv3/core/dataformat/Tensor.h
@@ -2,7 +2,7 @@
  * \file Tensor.h
  *
  * \ingroup core_DataFormat
- * 
+ *
  * \brief Class def header for an tensor data holder larcv3::Tensor (was Image2D)
  *
  * @author tmw, kazu, cadams
@@ -19,7 +19,10 @@
 #include <cstdlib>
 #include "larcv3/core/dataformat/ImageMeta.h"
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#endif
 
 namespace larcv3 {
 
@@ -31,7 +34,7 @@ namespace larcv3 {
   template<size_t dimension>
   class Tensor {
     template<size_t> friend class EventTensor;
-    
+
   public:
 
     /// Default Constructor:
@@ -46,12 +49,15 @@ namespace larcv3 {
     /// copy ctor
     Tensor(const Tensor&);
 
+
+    // These functions only appear in larcv proper, not in included headers:
+#ifdef LARCV_INTERNAL
     /// from numpy ctor
     Tensor(pybind11::array_t<float>);
 
     // Return a numpy array of this object (no copy by default)
     pybind11::array_t<float> as_array();
-    
+#endif
 
     /// dtor
     virtual ~Tensor(){}
@@ -84,7 +90,7 @@ namespace larcv3 {
     // /// Crop specified region via crop_meta to generate a new larcv3::Image2D
     // Image2D crop(const ImageMeta& crop_meta) const;
     /// 1D const reference array getter
-    const std::vector<float>& as_vector() const 
+    const std::vector<float>& as_vector() const
     { return _img; }
     // /// Re-size the 1D data array w/ updated # rows and # columns
     // void resize( const std::vector<size_t> &  counts, float fillval=0.0 );
@@ -96,7 +102,7 @@ namespace larcv3 {
     void paint(float value);
     /// Apply threshold: pixels lower than "thres" are all overwritten by lower_overwrite value
     void threshold(float thresh, bool lower);
-    /// Apply threshold: make all pixels to take only 2 values, lower_overwrite or upper_overwrite 
+    /// Apply threshold: make all pixels to take only 2 values, lower_overwrite or upper_overwrite
     void binarize(float thresh, float lower_overwrite, float upper_overwrite);
     /// Clear data contents
     void clear_data();
@@ -141,7 +147,7 @@ namespace larcv3 {
     void eltwise( const Tensor& rhs );
     /// Element-wise multiplication w/ 1D array data
     void eltwise(const std::vector<float>& arr,bool allow_longer=false);
-    
+
     // The following functions were deprecated for larcv3.
     // Implementations are here in the source code until a later cleanup, in case they
     // need to be un deprecated:
@@ -152,7 +158,7 @@ namespace larcv3 {
 
     /// Move origin position
     void reset_origin(double x, double y) {_meta.reset_origin(x,y);}
-    
+
     /// Compress image2D data and returns compressed data 1D array
     std::vector<float> copy_compress(size_t row_count, size_t col_count, CompressionModes_t mode=kSum) const;
 
@@ -162,10 +168,10 @@ namespace larcv3 {
     void paint_col( int col, float value );
     /// Call copy_compress internally and set itself to the result
     void compress(size_t row_count, size_t col_count, CompressionModes_t mode=kSum);
-    
+
     // Matrix Multiplication
     /// Matrix multiplicaition
-    Image2D multiRHS( const Image2D& rhs ) const; 
+    Image2D multiRHS( const Image2D& rhs ) const;
 
 
     // /// uniry operator for matrix multiplicaition
@@ -187,11 +193,13 @@ namespace larcv3 {
 
 }
 
+#ifdef LARCV_INTERNAL
+
 template <size_t dimension>
 void init_tensor_base(pybind11::module m);
 
 void init_tensor(pybind11::module m);
-
+#endif
 
 #endif
-/** @} */ // end of doxygen group 
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/Vertex.h
+++ b/src/larcv3/core/dataformat/Vertex.h
@@ -76,7 +76,7 @@ namespace larcv3 {
                   HOFFSET (Vertex, _y), larcv3::get_datatype<double>());
       H5Tinsert (datatype, "z",
                   HOFFSET (Vertex, _z), larcv3::get_datatype<double>());
-      H5Tinsert (datatype, "t", 
+      H5Tinsert (datatype, "t",
                   HOFFSET (Vertex, _t), larcv3::get_datatype<double>());
       return datatype;
     }
@@ -85,7 +85,9 @@ namespace larcv3 {
 
   };
 }
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_vertex(pybind11::module m);
+#endif
 
 #endif

--- a/src/larcv3/core/dataformat/Voxel.h
+++ b/src/larcv3/core/dataformat/Voxel.h
@@ -18,7 +18,10 @@
 #include "larcv3/core/dataformat/ImageMeta.h"
 #include "larcv3/core/dataformat/Tensor.h"
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 #include <pybind11/numpy.h>
+#endif
 
 namespace larcv3 {
 
@@ -96,7 +99,7 @@ namespace larcv3 {
       datatype = H5Tcreate (H5T_COMPOUND, sizeof (Voxel));
       H5Tinsert (datatype, "id",
                   HOFFSET (Voxel, _id), larcv3::get_datatype<unsigned long>());
-      H5Tinsert (datatype, "value", 
+      H5Tinsert (datatype, "value",
                   HOFFSET (Voxel, _value), larcv3::get_datatype<float>());
       return datatype;
     }
@@ -178,12 +181,15 @@ namespace larcv3 {
     /// Size (count) of voxels
     inline size_t size() const { return _voxel_v.size(); }
 
+
+// These functions only appear in larcv proper, not in includes:
+#ifdef LARCV_INTERNAL
     /// Get the value of all voxels in this set
     pybind11::array_t<float> values() const;
 
     /// Get the index of all voxels in this set
     pybind11::array_t<size_t> indexes() const;
-
+#endif
 
     /// Get the value of all voxels in this set
     std::vector<float> values_vec() const;
@@ -408,6 +414,9 @@ typedef SparseCluster<3> SparseCluster3D;
 
 }
 
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
+#include <pybind11/numpy.h>
 void init_voxel_core(pybind11::module m);
 
 template<size_t dimension>
@@ -417,6 +426,7 @@ template<size_t dimension>
 void init_sparse_cluster(pybind11::module m);
 
 void init_voxel(pybind11::module m);
+#endif
 
 #endif
 /** @} */ // end of doxygen group

--- a/src/larcv3/core/dataformat/dataformat.h
+++ b/src/larcv3/core/dataformat/dataformat.h
@@ -2,7 +2,7 @@
  * \file larbys.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief Class def header for exception classes for larcv3 framework
  *
  * @author cadams
@@ -33,10 +33,10 @@
 #include "Voxel.h"
 
 #ifndef LARCV_NO_PYBIND
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 __attribute__ ((visibility ("default"))) void init_dataformat(pybind11::module m);
-
-
+#endif
 // bindings
 #endif
 

--- a/src/larcv3/core/processor/ProcessBase.h
+++ b/src/larcv3/core/processor/ProcessBase.h
@@ -2,7 +2,7 @@
  * \file ProcessBase.h
  *
  * \ingroup core_Processor
- * 
+ *
  * \brief Class def header for a class larcv3::ProcessBase
  *
  * @author drinkingkazu
@@ -36,10 +36,10 @@ namespace larcv3 {
     friend class ProcessFactory;
 
   public:
-    
+
     /// Default constructor
     ProcessBase(const std::string name="ProcessBase");
-    
+
     /// Default destructor
     virtual ~ProcessBase(){}
 
@@ -56,7 +56,7 @@ namespace larcv3 {
     virtual void finalize() = 0;
 
     //
-    // Following functions are 
+    // Following functions are
     //
     /// Only for experts: allows a loose grouping for a set of ProcessBase inherit classes via true/false return to a "question".
     virtual bool is(const std::string question) const;
@@ -74,15 +74,16 @@ namespace larcv3 {
     larcv3::Watch _watch;    ///< algorithm profile stopwatch
     double _proc_time;      ///< algorithm execution time record (cumulative)
     size_t _proc_count;     ///< algorithm execution counter (cumulative)
-    
+
     larcv3::ProcessID_t _id; ///< unique algorithm identifier
     bool _profile;          ///< measure process time if profile flag is on
     std::string _typename;  ///< process type from factory
   };
 }
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_processbase(pybind11::module m);
+#endif
 
 #endif
-/** @} */ // end of doxygen group 
-
+/** @} */ // end of doxygen group

--- a/src/larcv3/core/processor/ProcessDriver.h
+++ b/src/larcv3/core/processor/ProcessDriver.h
@@ -115,9 +115,10 @@ namespace larcv3 {
     bool _has_event_creator;
   };
 }
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 void init_processdriver(pybind11::module m);
-
+#endif
 
 #endif
 /** @} */ // end of doxygen group

--- a/src/larcv3/core/processor/processor.h
+++ b/src/larcv3/core/processor/processor.h
@@ -2,7 +2,7 @@
  * \file larbys.h
  *
  * \ingroup core_Base
- * 
+ *
  * \brief Class def header for exception classes for larcv3 framework
  *
  * @author cadams
@@ -20,9 +20,10 @@
 
 
 #ifndef LARCV_NO_PYBIND
-
+#ifdef LARCV_INTERNAL
+#include <pybind11/pybind11.h>
 __attribute__ ((visibility ("default"))) void init_processor(pybind11::module m);
-
+#endif
 
 // bindings
 #endif


### PR DESCRIPTION
… headers.  When compiling locally, pybind11 is used.  When including larcv headers, pybind11 is unused.